### PR TITLE
check whether the current dir is whitelisted when sending events to kited

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,8 @@
 Kite for Atom
 =============
 
-### Development
+Kite gives you completions and documentation in Atom, sorted by popularity.
 
-To get this plugin up and running in development:
+We'll be adding many more features very soon.
 
-```shell
-$ git clone git@github.com:kiteco/atom-plugin.git
-$ cd atom-plugin
-$ npm install   # installs dependencies of this package
-$ apm link .    # symlinks kite into atom packages dir
-```
-
-Then restart Atom. Kite should appear in the list of packages.
+You can learn more about the broader Kite product at <http://kite.com>.  As part of this package, you also get the Kite Sidebar, which shows more information as you're working.  You can access the Kite Sidebar by launching Kite in your Applications folder.

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -1,5 +1,6 @@
-var http = require('http');
-var utils = require('./utils.js');
+const http = require('http');
+const utils = require('./utils.js');
+const metrics = require('./metrics.js');
 
 // called to handle attribute completions
 function getSuggestions(params) {
@@ -49,10 +50,12 @@ function getSuggestions(params) {
           var suggestions = [];
           for (var i = 0; i < resp.completions.length; i++) {
             var c = resp.completions[i];
+            console.log(c);
             suggestions.push({
               text: c.display,
               type: c.hint,
               rightLabel: c.hint,
+              description: c.documentation_text || "",
             });
           }
           resolve(suggestions);
@@ -76,6 +79,13 @@ function getSuggestions(params) {
   });
 }
 
+function onDidInsertSuggestion(ev) {
+  // ev has three fields: editor, triggerPosition, suggestion
+  metrics.track("completion used", {
+    text: ev.suggestion.text,
+  });
+}
+
 module.exports = {
   selector: '.source.python',
   disableForSelector: '.source.python .comment, .source.python .string',
@@ -83,4 +93,5 @@ module.exports = {
   suggestionPriority: 5,
   excludeLowerPriority: false,
   getSuggestions: getSuggestions,
+  onDidInsertSuggestion: onDidInsertSuggestion,
 };

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -79,8 +79,8 @@ function getSuggestions(params) {
 module.exports = {
   selector: '.source.python',
   disableForSelector: '.source.python .comment, .source.python .string',
-  inclusionPriority: 2,
-  suggestionPriority: 2,
+  inclusionPriority: 5,
+  suggestionPriority: 5,
   excludeLowerPriority: false,
   getSuggestions: getSuggestions,
 };

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -50,7 +50,6 @@ function getSuggestions(params) {
           var suggestions = [];
           for (var i = 0; i < resp.completions.length; i++) {
             var c = resp.completions[i];
-            console.log(c);
             suggestions.push({
               text: c.display,
               type: c.hint,

--- a/lib/elements/login.js
+++ b/lib/elements/login.js
@@ -35,19 +35,19 @@ var LoginStep = class {
     this.submitBtn.textContent = "Sign in to Kite";
     this.element.appendChild(this.submitBtn);
 
-    this.cancelBtn = document.createElement('button');
-    this.cancelBtn.classList.add('btn');
-    this.cancelBtn.classList.add('btn-large');
-    this.cancelBtn.classList.add('inline-block');
-    this.cancelBtn.textContent = "Cancel";
-    this.element.appendChild(this.cancelBtn);
-
     this.resetBtn = document.createElement('button');
     this.resetBtn.classList.add('btn');
     this.resetBtn.classList.add('btn-large');
     this.resetBtn.classList.add('inline-block');
     this.resetBtn.textContent = "Reset Password";
     this.element.appendChild(this.resetBtn);
+
+    this.cancelBtn = document.createElement('button');
+    this.cancelBtn.classList.add('btn');
+    this.cancelBtn.classList.add('btn-large');
+    this.cancelBtn.classList.add('inline-block');
+    this.cancelBtn.textContent = "Cancel";
+    this.element.appendChild(this.cancelBtn);
   }
 
   destroy() {

--- a/lib/elements/login.js
+++ b/lib/elements/login.js
@@ -41,6 +41,13 @@ var LoginStep = class {
     this.cancelBtn.classList.add('inline-block');
     this.cancelBtn.textContent = "Cancel";
     this.element.appendChild(this.cancelBtn);
+
+    this.resetBtn = document.createElement('button');
+    this.resetBtn.classList.add('btn');
+    this.resetBtn.classList.add('btn-large');
+    this.resetBtn.classList.add('inline-block');
+    this.resetBtn.textContent = "Reset Password";
+    this.element.appendChild(this.resetBtn);
   }
 
   destroy() {
@@ -90,6 +97,10 @@ var LoginStep = class {
 
   onCancel(func) {
     this.cancelBtn.onclick = func;
+  }
+
+  onResetPassword(func) {
+    this.resetBtn.onclick = func;
   }
 
   get email() {

--- a/lib/events.js
+++ b/lib/events.js
@@ -41,8 +41,8 @@ function reset() {
   PENDING_EVENTS = [];
 }
 
-// minimum interval in milliseconds between sending "could not connect..." events to mixpanel
-const CONNECT_ERROR_LOCKOUT = 15 * 60 * 1000;
+// minimum interval in seconds between sending "could not connect..." events to mixpanel
+const CONNECT_ERROR_LOCKOUT = 15 * 60;
 
 // last time we sent a "could not connect..." event to mixpanel
 var lastConnectError = null;
@@ -67,7 +67,7 @@ function mergeEvents() {
     }
   }, (err) => {
     // on connection error send a metric
-    if (lastConnectError === null || utils.timeSince(lastConnectError) >= CONNECT_ERROR_LOCKOUT) {
+    if (lastConnectError === null || utils.secondsSince(lastConnectError) >= CONNECT_ERROR_LOCKOUT) {
       lastConnectError = new Date();
       metrics.track("could not connect to event endpoint", err);
     }

--- a/lib/events.js
+++ b/lib/events.js
@@ -137,6 +137,18 @@ function onEdit(editor) {
 function onSelection(editor) {
   send(buildEvent(editor, "selection"));
 }
+function onActivate() {
+  // observeTextEditors takes a callback that fires whenever a new
+  // editor window is created. We use this to call "observeEditor",
+  // which registers edit/selection based callbacks.
+  atom.workspace.observeTextEditors(observeEditor);
+
+  // focus is tracked at the workspace level.
+  atom.workspace.onDidChangeActivePaneItem(onFocus);
+
+  // send the activate event so that kite knows the plugin is ready
+  send(makeEvent("activate", "", "", 0));
+}
 
 // buildEvent constructs an event from the provided editor. It sets the
 // "action" field of the event to the provided value.
@@ -151,19 +163,22 @@ function buildEvent(editor, action) {
     text = "file_too_large";
   }
 
+  return makeEvent(action, editor.getPath(), text, cursorOffset);
+}
+
+function makeEvent(action, filename, text, cursor) {
   return {
     source: "atom",
     action: action,
-    filename: editor.getPath(),
+    filename: filename,
     text: text,
     selections: [{
-      start: cursorOffset,
-      end: cursorOffset,
+      start: cursor,
+      end: cursor,
     }],
   };
 }
 
 module.exports = {
-  observeEditor: observeEditor,
-  onFocus: onFocus,
+  onActivate: onActivate,
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -55,7 +55,6 @@ function mergeEvents() {
     console.log(event.action, event.filename, event.selections[0]);
   }
   httpRoundTrip('/clientapi/editor/event', event).then((resp) => {
-    console.log(`event endpoint returned status code ${resp.statusCode}`);
     if (resp.statusCode == 423) {
       // the path is not whitelisted, trigger a notification
       ready.ensure();
@@ -81,7 +80,7 @@ function sendError(msg) {
   });
 }
 
-// httpRoundTrip - performs a POST request and discards the result
+// httpRoundTrip - performs a POST request and returns a promise for the result
 function httpRoundTrip(endpoint, obj) {
   return new Promise((resolve, reject) => {
     var payload = JSON.stringify(obj);

--- a/lib/events.js
+++ b/lib/events.js
@@ -54,7 +54,17 @@ function mergeEvents() {
   if (DEBUG) {
     console.log(event.action, event.filename, event.selections[0]);
   }
-  httpRoundTrip('/clientapi/editor/event', event)
+  httpRoundTrip('/clientapi/editor/event', event).then((resp) => {
+    console.log(`event endpoint returned status code ${resp.statusCode}`);
+    if (resp.statusCode == 423) {
+      // the path is not whitelisted, trigger a notification
+      ready.ensure();
+    }
+  }, (err) => {
+    // on connection error trigger a status check
+    metrics.track("could not connect to event endpoint", err);
+    ready.ensure();
+  });
   reset();
 }
 
@@ -73,28 +83,31 @@ function sendError(msg) {
 
 // httpRoundTrip - performs a POST request and discards the result
 function httpRoundTrip(endpoint, obj) {
-  var payload = JSON.stringify(obj);
-  if (payload.length > MAX_PAYLOAD_SIZE) {
-    console.log("unable to send message because length exceeded limit");
-    reset();
-    return;
-  }
+  return new Promise((resolve, reject) => {
+    var payload = JSON.stringify(obj);
+    if (payload.length > MAX_PAYLOAD_SIZE) {
+      console.log("unable to send message because length exceeded limit");
+      reset();
+      return;
+    }
 
-  var options = {
-    host: '127.0.0.1',
-    port: '46624',
-    path: endpoint,
-    method: 'POST',
-  };
+    var options = {
+      host: '127.0.0.1',
+      port: '46624',
+      path: endpoint,
+      method: 'POST',
+    };
 
-  var req = http.request(options);
-  req.on('error', (err) => {
-    err[endpoint] = endpoint;
-    metrics.track("http connection failed", err);
-    ready.ensure();
+    var req = http.request(options);
+    req.on('error', (err) => {
+      reject(err);
+    });
+    req.on('response', (resp) => {
+      resolve(resp);
+    });
+    req.write(payload);
+    req.end();
   });
-  req.write(payload);
-  req.end();
 }
 
 // callback handlers to track edit/selection/focus events

--- a/lib/events.js
+++ b/lib/events.js
@@ -61,7 +61,7 @@ function mergeEvents() {
     console.log(event.action, event.filename, event.selections[0]);
   }
   httpRoundTrip('/clientapi/editor/event', event).then((resp) => {
-    if (resp.statusCode == 423) {
+    if (resp.statusCode === 423) {
       // the path is not whitelisted, trigger a notification
       ready.ensure();
     }

--- a/lib/events.js
+++ b/lib/events.js
@@ -41,6 +41,12 @@ function reset() {
   PENDING_EVENTS = [];
 }
 
+// minimum interval in milliseconds between sending "could not connect..." events to mixpanel
+const CONNECT_ERROR_LOCKOUT = 15 * 60 * 1000;
+
+// last time we sent a "could not connect..." event to mixpanel
+var lastConnectError = null;
+
 // called after a string of events have fired for a particular keystroke. We use this
 // to debounce the events - pick the last event and set it to edit of any of the events
 // we accumulated was in fact an edit.
@@ -60,9 +66,11 @@ function mergeEvents() {
       ready.ensure();
     }
   }, (err) => {
-    // on connection error trigger a status check
-    metrics.track("could not connect to event endpoint", err);
-    ready.ensure();
+    // on connection error send a metric
+    if (lastConnectError === null || utils.timeSince(lastConnectError) >= CONNECT_ERROR_LOCKOUT) {
+      lastConnectError = new Date();
+      metrics.track("could not connect to event endpoint", err);
+    }
   });
   reset();
 }
@@ -97,12 +105,16 @@ function httpRoundTrip(endpoint, obj) {
       method: 'POST',
     };
 
-    var req = http.request(options);
+    var req = http.request(options, (resp) => {
+      resp.on('error', (err) => {
+        reject(err);
+      });
+      resp.on('end', () => {
+        resolve(resp);
+      });
+    });
     req.on('error', (err) => {
       reject(err);
-    });
-    req.on('response', (resp) => {
-      resolve(resp);
     });
     req.write(payload);
     req.end();

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -20,7 +20,7 @@ module.exports = {
     // install hooks for readiness checker and check that Kite is running
     ready.onActivate();
 
-    // run apm upgrade kite
+    // run "apm upgrade kite"
     this.selfUpdate();
 
     // watch for the user checking the "check kite status" config item
@@ -50,7 +50,7 @@ module.exports = {
   },
   selfUpdate: function() {
     var apm = atom.packages.getApmPath();
-    child_process.spawnSync(apm, ['update', 'kite']);
+    child_process.spawn(apm, ['update', 'kite']);
   },
   completions: function() {
     return completions;

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -1,5 +1,8 @@
 // Contents of this plugin will be reset by Kite on start. Changes you make
 // are not guaranteed to persist.
+
+const child_process = require('child_process');
+
 const events = require('./events.js');
 const completions = require('./completions.js');
 const ready = require('./ready.js');
@@ -11,16 +14,14 @@ module.exports = {
     // send the activated event
     metrics.track("activated");
 
-    // observeTextEditors takes a callback that fires whenever a new
-    // editor window is created. We use this to call "observeEditor",
-    // which registers edit/selection based callbacks.
-    atom.workspace.observeTextEditors(events.observeEditor);
+    // install hooks for editor events and send the activate event
+    events.onActivate();
 
-    // focus is tracked at the workspace level.
-    atom.workspace.onDidChangeActivePaneItem(events.onFocus);
+    // install hooks for readiness checker and check that Kite is running
+    ready.onActivate();
 
-    // install hooks and check that Kite is running
-    ready.onStartup();
+    // run apm upgrade kite
+    this.selfUpdate();
 
     // watch for the user checking the "check kite status" config item
     var firstObservation = true;
@@ -46,6 +47,10 @@ module.exports = {
       metrics.track("readiness config checkbox touched");
       ready.ensureAndNotify();
     });
+  },
+  selfUpdate: function() {
+    var apm = atom.packages.getApmPath();
+    child_process.spawnSync(apm, ['update', 'kite']);
   },
   completions: function() {
     return completions;

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -19,8 +19,8 @@ module.exports = {
     // focus is tracked at the workspace level.
     atom.workspace.onDidChangeActivePaneItem(events.onFocus);
 
-    // check that Kite is running
-    ready.ensure();
+    // install hooks and check that Kite is running
+    ready.onStartup();
 
     // watch for the user checking the "check kite status" config item
     var firstObservation = true;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const kitePkg = require('../package.json');
 const localconfig = require('./localconfig.js');
 
-const MIXPANEL_TOKEN = '2ab52cc896c9c74a7452d65f00e4f938';
+const MIXPANEL_TOKEN = 'fb6b9b336122a8b29c60f4c28dab6d03';
 
 const OS_VERSION = os.type() + ' ' + os.release();
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -32,6 +32,7 @@ function track(eventName, properties) {
   }
   eventData = {
     distinct_id: distinctID(),
+    editor: "atom",
     atom_version: atom.getVersion(),
     kite_plugin_version: kitePkg.version,
     os: OS_VERSION,
@@ -39,7 +40,7 @@ function track(eventName, properties) {
   for (var key in properties || {}) {
     eventData[key] = properties[key];
   }
-  client.track(eventName, properties);
+  client.track(eventName, eventData);
 }
 
 module.exports = {

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -8,8 +8,8 @@ const utils = require('./utils.js');
 const metrics = require('./metrics.js');
 const Login = require('./elements/login.js');
 
-// minimum time between showing the same notification, in milliseconds
-const NOTIFY_DELAY = 60 * 60 * 1000;
+// minimum time between showing the same notification, in seconds
+const NOTIFY_DELAY = 60 * 60;
 
 var Ready = {
   onActivate: function() {
@@ -108,9 +108,8 @@ var Ready = {
   // shouldNotify returns true if the user should be notified about the given
   // failure detected by ensure
   shouldNotify: function(state) {
-    var now = new Date();
     var prev = this.lastRejected[state];
-    return prev === undefined || (now.getTime() - prev.getTime()) >= NOTIFY_DELAY;
+    return prev === undefined || utils.secondsSince(prev) >= NOTIFY_DELAY;
   },
 
   warnNotSupported: function() {

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -161,7 +161,7 @@ var Ready = {
       // if install failed because kite is already installed then ignore
       var curState = err.data || 0;
       if (curState >= StateController.STATES.INSTALLED) {
-        console.log("download-and-install failed because kite is already installed (state { curState })");
+        console.log("download-and-install failed because kite is already installed (state ${ curState })");
         return;
       }
 
@@ -381,7 +381,7 @@ var Ready = {
       // if whitelist failed because dir is already whitelisted then ignore
       var curState = err.data || 0;
       if (curState >= StateController.STATES.WHITELISTED) {
-        console.log("whitelist failed because dir is already whitelisted (state { curState })");
+        console.log("whitelist failed because dir is already whitelisted (state ${ curState })");
         return;
       }
 

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -19,7 +19,7 @@ var Ready = {
   },
 
   // lastRejected contains the last time the user rejected a notification for
-  // thegiven state. It is used to prevent bugging the user too frequently with
+  // the given state. It is used to prevent bugging the user too frequently with
   // notifications.
   lastRejected: {},
 

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -21,7 +21,8 @@ var Ready = {
     atom.workspace.onDidChangeActivePaneItem((item) => {
       this.ensureIfPython();
     });
-    this.ensure();
+
+    setTimeout(this.ensure.bind(this));
   },
 
   // ensure checks that Kite is installed, running, reachable, authenticated,

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -268,6 +268,15 @@ var Ready = {
       login.destroy();
       metrics.track("cancel clicked in login panel");
     });
+
+    login.onResetPassword(() => {
+      metrics.track("reset password clicked in login panel");
+      var url = `https://alpha.kite.com/account/resetPassword/request?email={ login.email }`;
+      child_process.spawnSync('open', url);
+      panel.destroy();
+      login.destroy();
+    });
+
     login.onSubmit(() => {
       var email = login.email;
       var password = login.password;

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -18,21 +18,17 @@ var Ready = {
     return editor.buffer.file.path;
   },
 
-  // lastNotify contains the last time we notified the user about being in the
-  // given state. It is used to prevent bugging the user too frequently with
+  // lastRejected contains the last time the user rejected a notification for
+  // thegiven state. It is used to prevent bugging the user too frequently with
   // notifications.
-  lastNotified: {},
+  lastRejected: {},
 
   // shouldNotify returns true if the user should be notified about the given
   // failure detected by ensure
-  shouldNotify: function(state, forceNotify=false) {
+  shouldNotify: function(state) {
     var now = new Date();
-    var prev = this.lastNotified[state];
-    if (forceNotify || prev === undefined || (now.getTime() - prev.getTime()) >= NOTIFY_DELAY) {
-      this.lastNotified[state] = now;
-      return true;
-    }
-    return false;
+    var prev = this.lastRejected[state];
+    return prev === undefined || (now.getTime() - prev.getTime()) >= NOTIFY_DELAY;
   },
 
   // ensure checks that Kite is installed, running, reachable, authenticated,
@@ -44,17 +40,17 @@ var Ready = {
     StateController.handleState(curpath).then((state) => {
       switch (state) {
         case StateController.STATES.UNSUPPORTED:
-          if (this.shouldNotify(state, forceNotify)) {
+          if (this.shouldNotify(state) || forceNotify) {
             this.warnNotSupported();
           }
           break;
         case StateController.STATES.UNINSTALLED:
-          if (this.shouldNotify(state, forceNotify)) {
+          if (this.shouldNotify(state) || forceNotify) {
             this.warnNotInstalled();
           }
           break;
         case StateController.STATES.INSTALLED:
-          if (this.shouldNotify(state, forceNotify)) {
+          if (this.shouldNotify(state) || forceNotify) {
             this.warnNotRunning();
           }
           break;
@@ -62,13 +58,13 @@ var Ready = {
           // for now, ignore this
           break;
         case StateController.STATES.REACHABLE:
-          if (this.shouldNotify(state, forceNotify)) {
+          if (this.shouldNotify(state) || forceNotify) {
             this.warnNotAuthenticated();
           }
           break;
         case StateController.STATES.AUTHENTICATED:
           if (curpath !== null) {
-            if (this.shouldNotify(state, forceNotify)) {
+            if (this.shouldNotify(state) || forceNotify) {
               this.warnNotWhitelisted(curpath);
             }
           } else if (forceNotify) {
@@ -105,6 +101,7 @@ var Ready = {
   },
 
   warnNotInstalled: function() {
+    var rejected = true;
     metrics.track("not-installed warning shown");
     var notification = atom.notifications.addWarning(
       "The Kite autocomplete daemon is not installed", {
@@ -114,6 +111,7 @@ var Ready = {
       buttons: [{
         text: "Install Kite",
         onDidClick: () => {
+          rejected = false;  // so that onDidDismiss knows that this was not a reject
           metrics.track("install button clicked (via not-installed warning)");
           notification.dismiss();
           this.install();
@@ -121,7 +119,10 @@ var Ready = {
       }]
     });
     notification.onDidDismiss(() => {
-      metrics.track("not-installed warning dismissed");
+      if (rejected) {
+        this.lastRejected[StateController.STATES.UNINSTALLED] = new Date();
+        metrics.track("not-installed warning dismissed");
+      }
     });
   },
 
@@ -151,6 +152,7 @@ var Ready = {
   },
 
   warnNotRunning: function() {
+    var rejected = true;
     metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
       "The Kite autocomplete daemon is not running", {
@@ -160,6 +162,7 @@ var Ready = {
       buttons: [{
         text: "Start Kite",
         onDidClick: () => {
+          rejected = false;  // so that onDidDismiss knows that this was not a reject
           metrics.track("start button clicked (via not-running warning)");
           notification.dismiss();
           this.launch();
@@ -167,7 +170,10 @@ var Ready = {
       }]
     });
     notification.onDidDismiss(() => {
-      metrics.track("not-running warning dismissed");
+      if (rejected) {
+        this.lastRejected[StateController.STATES.INSTALLED] = new Date();
+        metrics.track("not-running warning dismissed");
+      }
     });
   },
 
@@ -205,10 +211,12 @@ var Ready = {
       dismissable: true,
     }).onDidDismiss(() => {
       metrics.track("not-reachable warning dismissed");
+      this.lastRejected[StateController.STATES.RUNNING] = new Date();
     });
   },
 
   warnNotAuthenticated: function() {
+    var rejected = true;
     metrics.track("not-authenticated warning shown");
     var notification = atom.notifications.addWarning(
       "You need to log in to the Kite autocomplete daemon", {
@@ -218,6 +226,7 @@ var Ready = {
       buttons: [{
         text: "Login",
         onDidClick: () => {
+          rejected = false;  // so that onDidDismiss knows that this was not a reject
           metrics.track("login button clicked (via not-authenticated warning)");
           notification.dismiss();
           this.authenticate();
@@ -225,7 +234,10 @@ var Ready = {
       }]
     });
     notification.onDidDismiss(() => {
-      metrics.track("not-authenticated warning dismissed");
+      if (rejected) {
+        this.lastRejected[StateController.STATES.REACHABLE] = new Date();
+        metrics.track("not-authenticated warning dismissed");
+      }
     });
   },
 
@@ -274,6 +286,7 @@ var Ready = {
     var dir = path.dirname(filepath);
     metrics.track("not-whitelisted warning shown", {dir: dir});
 
+    var rejected = true;
     var notification = atom.notifications.addWarning(
       "Kite completions are not enabled for "+filepath, {
       description: "Kite only processes files in enabled directories. If you enable Kite then files in this directory will be synced to the Kite backend, where they will be analyzed and indexed.",
@@ -282,6 +295,7 @@ var Ready = {
       buttons: [{
         text: "Enable Kite for "+dir,
         onDidClick: () => {
+          rejected = false;  // so that onDidDismiss knows that this was not a reject
           metrics.track("enable button clicked (via not-whitelisted warning)", {dir: dir});
           notification.dismiss();
           this.whitelist(dir);
@@ -289,7 +303,10 @@ var Ready = {
       }]
     });
     notification.onDidDismiss(() => {
-      metrics.track("not-whitelisted warning dismissed", {dir: dir});
+      if (rejected) {
+        metrics.track("not-whitelisted warning dismissed", {dir: dir});
+        this.lastRejected[StateController.STATES.AUTHENTICATED] = new Date();
+      }
     });
   },
 

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -133,6 +133,15 @@ var Ready = {
       this.launch();
     }, (err) => {
       metrics.track("download-and-install failed", err);
+
+      // if install failed because kite is already installed then ignore
+      var curState = err.data || 0;
+      if (curState >= StateController.STATES.INSTALLED) {
+        console.log("download-and-install failed because kite is already installed (state { curState })");
+        return;
+      }
+
+      // show an error notification with an option to retry
       var notification = atom.notifications.addError("Unable to install Kite", {
         description: JSON.stringify(err),
         dismissable: true,
@@ -184,6 +193,15 @@ var Ready = {
       this.ensure();
     }, (err) => {
       metrics.track("launch failed", err);
+
+      // if launch failed because kite is already running then ignore
+      var curState = err.data || 0;
+      if (curState >= StateController.STATES.RUNNING) {
+        console.log("launch failed because kite is already installed (state { curState })");
+        return;
+      }
+
+      // show an error notification with an option to retry
       var notification = atom.notifications.addError("Unable to start Kite autocomplete daemon", {
         description: JSON.stringify(err),
         dismissable: true,
@@ -263,6 +281,15 @@ var Ready = {
         this.ensure();
       }, (err) => {
         metrics.track("authentication failed", err);
+
+        // if authentication failed because kite is already authenticated then ignore
+        var curState = err.data || 0;
+        if (curState >= StateController.STATES.AUTHENTICATED) {
+          console.log("launch failed because kite is already installed (state { curState })");
+          return;
+        }
+
+        // show an error notification with an option to retry
         var notification = atom.notifications.addError("Unable to login", {
           description: JSON.stringify(err),
           dismissable: true,
@@ -317,6 +344,15 @@ var Ready = {
       this.ensure();
     }, (err) => {
       metrics.track("whitelisting failed", {dir: dirpath});
+
+      // if whitelist failed because dir is already whitelisted then ignore
+      var curState = err.data || 0;
+      if (curState >= StateController.STATES.WHITELISTED) {
+        console.log("whitelist failed because dir is already whitelisted (state { curState })");
+        return;
+      }
+
+      // show an error notification with an option to retry
       var notification = atom.notifications.addError("Unable to enable Kite for "+dirpath, {
         description: JSON.stringify(err),
         dismissable: true,

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -12,7 +12,7 @@ const Login = require('./elements/login.js');
 const NOTIFY_DELAY = 60 * 60 * 1000;
 
 var Ready = {
-  onStartup: function() {
+  onActivate: function() {
     atom.workspace.observeTextEditors((editor) => {
       editor.onDidChangePath(() => {
         this.ensureIfPython();

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -1,5 +1,7 @@
 const os = require('os');
 const path = require('path');
+const child_process = require('child_process');
+
 const StateController = require('kite-installer').StateController;
 
 const utils = require('./utils.js');
@@ -197,7 +199,7 @@ var Ready = {
       // if launch failed because kite is already running then ignore
       var curState = err.data || 0;
       if (curState >= StateController.STATES.RUNNING) {
-        console.log("launch failed because kite is already installed (state { curState })");
+        console.log(`launch failed because kite is already installed (state ${curState})`);
         return;
       }
 
@@ -271,8 +273,8 @@ var Ready = {
 
     login.onResetPassword(() => {
       metrics.track("reset password clicked in login panel");
-      var url = `https://alpha.kite.com/account/resetPassword/request?email={ login.email }`;
-      child_process.spawnSync('open', url);
+      var url = `https://alpha.kite.com/account/resetPassword/request?email=${login.email}`;
+      child_process.spawn('open', [url]);
       panel.destroy();
       login.destroy();
     });
@@ -294,7 +296,7 @@ var Ready = {
         // if authentication failed because kite is already authenticated then ignore
         var curState = err.data || 0;
         if (curState >= StateController.STATES.AUTHENTICATED) {
-          console.log("launch failed because kite is already installed (state { curState })");
+          console.log(`launch failed because kite is already installed (state ${curState})`);
           return;
         }
 

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -12,25 +12,16 @@ const Login = require('./elements/login.js');
 const NOTIFY_DELAY = 60 * 60 * 1000;
 
 var Ready = {
-  currentPath: function() {
-    var editor = atom.workspace.getActivePaneItem();
-    if (editor === undefined || editor.buffer == undefined || editor.buffer.file == undefined) {
-      return null;
-    }
-    return editor.buffer.file.path;
-  },
-
-  // lastRejected contains the last time the user rejected a notification for
-  // the given state. It is used to prevent bugging the user too frequently with
-  // notifications.
-  lastRejected: {},
-
-  // shouldNotify returns true if the user should be notified about the given
-  // failure detected by ensure
-  shouldNotify: function(state) {
-    var now = new Date();
-    var prev = this.lastRejected[state];
-    return prev === undefined || (now.getTime() - prev.getTime()) >= NOTIFY_DELAY;
+  onStartup: function() {
+    atom.workspace.observeTextEditors((editor) => {
+      editor.onDidChangePath(() => {
+        this.ensureIfPython();
+      });
+    });
+    atom.workspace.onDidChangeActivePaneItem((item) => {
+      this.ensureIfPython();
+    });
+    this.ensure();
   },
 
   // ensure checks that Kite is installed, running, reachable, authenticated,
@@ -88,6 +79,38 @@ var Ready = {
   // ensureAndNotify is like ensure but also shows a success notification if Kite is already running.
   ensureAndNotify: function() {
     this.ensure(true);
+  },
+
+  // ensureIfPython  ensure only if the currently active file extension matches that provided
+  ensureIfPython: function() {
+    var curpath = this.currentPath();
+    //console.log(`curpath=${curpath} ext=${path.extname(curpath||"")}`);
+    if (curpath !== null && path.extname(curpath) === ".py") {
+      console.log("calling ensure");
+      this.ensure();
+    }
+  },
+
+  // currentPath gets the path for the current text editor
+  currentPath: function() {
+    var editor = atom.workspace.getActivePaneItem();
+    if (editor === undefined || editor.buffer == undefined || editor.buffer.file == undefined) {
+      return null;
+    }
+    return editor.buffer.file.path;
+  },
+
+  // lastRejected contains the last time the user rejected a notification for
+  // the given state. It is used to prevent bugging the user too frequently with
+  // notifications.
+  lastRejected: {},
+
+  // shouldNotify returns true if the user should be notified about the given
+  // failure detected by ensure
+  shouldNotify: function(state) {
+    var now = new Date();
+    var prev = this.lastRejected[state];
+    return prev === undefined || (now.getTime() - prev.getTime()) >= NOTIFY_DELAY;
   },
 
   warnNotSupported: function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,13 +10,13 @@ function pointToOffset(text, point) {
   return total;
 }
 
-// get time in milliseconds since the date
-function timeSince(when) {
+// get time in seconds since the date
+function secondsSince(when) {
   var now = new Date();
-  return now.getTime() - when.getTime();
+  return (now.getTime() - when.getTime()) / 1000.;
 }
 
 module.exports = {
   pointToOffset: pointToOffset,
-  timeSince: timeSince,
+  secondsSince: secondsSince,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,13 @@ function pointToOffset(text, point) {
   return total;
 }
 
+// get time in milliseconds since the date
+function timeSince(when) {
+  var now = new Date();
+  return now.getTime() - when.getTime();
+}
+
 module.exports = {
   pointToOffset: pointToOffset,
+  timeSince: timeSince,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kite",
   "main": "./lib/kite",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A simple plugin to make Atom work with Kite",
   "repository": "https://github.com/kiteco/atom-plugin",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kite",
   "main": "./lib/kite",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A simple plugin to make Atom work with Kite",
   "repository": "https://github.com/kiteco/atom-plugin",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kite",
   "main": "./lib/kite",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Python programming copilot — Kite shows cloud-powered completions, documentation, and examples.",
   "repository": "https://github.com/kiteco/atom-plugin",
   "keywords": [],


### PR DESCRIPTION
This pr changes the kite plugin to check whether the current dir is whitelisted by checking the HTTP response code from the `/clientapi/editor/event` endpoint.

It also makes the following more minor changes:
- clicking a button in a notification does not trigger the one hour lockout for that notification.
- do not show launch error if the error was that kite is already running, and similarly for other errors
- bump up completions priority so that it always supercedes autocomplete-python
- add a "Reset password" button to the login UI