### PR TITLE
Updated copy for notification text

### DIFF
--- a/lib/ready.js
+++ b/lib/ready.js
@@ -95,7 +95,7 @@ var Ready = {
   warnNotSupported: function() {
     metrics.track("not-supported warning shown");
     atom.notifications.addError(
-      "OS not supported", {
+      "Kite doesn't support your OS", {
       description: "Sorry, the Kite autocomplete engine only supports macOS at the moment.",
       icon: "circle-slash",
       dismissable: true,
@@ -107,8 +107,8 @@ var Ready = {
   warnNotInstalled: function() {
     metrics.track("not-installed warning shown");
     var notification = atom.notifications.addWarning(
-      "Kite app missing", {
-      description: "Install Kite to get next-generation completions, documentation, and more.",
+      "The Kite autocomplete engine is not installed", {
+      description: "Install Kite to get Python completions, documentation, and examples.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -153,8 +153,8 @@ var Ready = {
   warnNotRunning: function() {
     metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
-      "Kite not running", {
-      description: "Start the Kite background service to get Python completions and docs.",
+      "The Kite autocomplete engine is not running", {
+      description: "Start the Kite background service to get Python completions, documentation, and examples.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -178,7 +178,7 @@ var Ready = {
       this.ensure();
     }, (err) => {
       metrics.track("launch failed", err);
-      var notification = atom.notifications.addError("Unable to start Kite autocomplete daemon", {
+      var notification = atom.notifications.addError("Unable to start Kite autocomplete engine", {
         description: JSON.stringify(err),
         dismissable: true,
         buttons: [{
@@ -211,7 +211,7 @@ var Ready = {
   warnNotAuthenticated: function() {
     metrics.track("not-authenticated warning shown");
     var notification = atom.notifications.addWarning(
-      "Kite not logged in", {
+      "You need to login to the Kite autocomplete engine", {
       description: "Kite needs to be authenticated, so that it can access the index of your code stored on the cloud.",
       icon: "circle-slash",
       dismissable: true,
@@ -275,7 +275,7 @@ var Ready = {
     metrics.track("not-whitelisted warning shown", {dir: dir});
 
     var notification = atom.notifications.addWarning(
-      "Kite is disabled for "+path.basename(filepath), {
+      "The Kite autocomplete engine is disabled for "+path.basename(filepath), {
       description: "Would you like to enable Kite for Python files in "+dir+"?",
       icon: "circle-slash",
       dismissable: true,
@@ -321,8 +321,8 @@ var Ready = {
   notifyReady: function() {
     metrics.track("ready notification shown");
     atom.notifications.addSuccess(
-      "The Kite background service is ready", {
-      description: "We checked that the background service is installed, running, responsive, and authenticated.",
+      "The Kite autocomplete engine is ready", {
+      description: "We checked that the autocomplete engine is installed, running, responsive, and authenticated.",
       dismissable: true,
     }).onDidDismiss(() => {
       metrics.track("ready notification dismissed");

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -95,8 +95,8 @@ var Ready = {
   warnNotSupported: function() {
     metrics.track("not-supported warning shown");
     atom.notifications.addError(
-      "The Kite autocomplete daemon is not supported on this platform", {
-      description: "Kite is currently only supported on macOS.",
+      "OS not supported", {
+      description: "Sorry, Kite only supports macOS at the moment.",
       icon: "circle-slash",
       dismissable: true,
     }).onDidDismiss(() => {
@@ -107,8 +107,8 @@ var Ready = {
   warnNotInstalled: function() {
     metrics.track("not-installed warning shown");
     var notification = atom.notifications.addWarning(
-      "The Kite autocomplete daemon is not installed", {
-      description: "In order to provide completions the Kite daemon needs to be installed.",
+      "Kite app missing", {
+      description: "Install the Kite app to get next-generation completions, documentation, and more.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -153,8 +153,8 @@ var Ready = {
   warnNotRunning: function() {
     metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
-      "The Kite autocomplete daemon is not running", {
-      description: "In order to provide completions the Kite daemon needs to be started.",
+      "Kite not running", {
+      description: "Start the Kite app to get Python completions and docs.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -200,8 +200,8 @@ var Ready = {
   warnNotReachable: function() {
     metrics.track("not-reachable warning shown");
     atom.notifications.addError(
-      "The Kite autocomplete daemon is running but not reachable", {
-      description: "Try killing Kite from Activity Monitor.",
+      "The Kite Menubar app is running but not reachable", {
+      description: "Try killing Kite from the Activity Monitor.",
       dismissable: true,
     }).onDidDismiss(() => {
       metrics.track("not-reachable warning dismissed");
@@ -211,8 +211,8 @@ var Ready = {
   warnNotAuthenticated: function() {
     metrics.track("not-authenticated warning shown");
     var notification = atom.notifications.addWarning(
-      "You need to log in to the Kite autocomplete daemon", {
-      description: "In order to provide completions the Kite daemon needs to be authenticated (so that it can access the index of your code stored on the cloud).",
+      "Kite not logged in", {
+      description: "Kite needs to be authenticated, so that it can access the index of your code stored on the cloud.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -275,12 +275,12 @@ var Ready = {
     metrics.track("not-whitelisted warning shown", {dir: dir});
 
     var notification = atom.notifications.addWarning(
-      "Kite completions are not enabled for "+filepath, {
-      description: "Kite only processes files in enabled directories. If you enable Kite then files in this directory will be synced to the Kite backend, where they will be analyzed and indexed.",
+      "Kite is disabled for "+path.basename(filepath), {
+      description: "Would you like to enable Kite for Python files in "+dir+"?",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
-        text: "Enable Kite for "+dir,
+        text: "Enable",
         onDidClick: () => {
           metrics.track("enable button clicked (via not-whitelisted warning)", {dir: dir});
           notification.dismiss();
@@ -321,8 +321,8 @@ var Ready = {
   notifyReady: function() {
     metrics.track("ready notification shown");
     atom.notifications.addSuccess(
-      "The Kite autocomplete daemon is ready", {
-      description: "We checked that the daemon is installed, running, responsive, and authenticated.",
+      "The Kite Menubar app is ready", {
+      description: "We checked that the Menubar app is installed, running, responsive, and authenticated.",
       dismissable: true,
     }).onDidDismiss(() => {
       metrics.track("ready notification dismissed");

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -96,7 +96,7 @@ var Ready = {
     metrics.track("not-supported warning shown");
     atom.notifications.addError(
       "OS not supported", {
-      description: "Sorry, Kite only supports macOS at the moment.",
+      description: "Sorry, the Kite autocomplete engine only supports macOS at the moment.",
       icon: "circle-slash",
       dismissable: true,
     }).onDidDismiss(() => {
@@ -108,7 +108,7 @@ var Ready = {
     metrics.track("not-installed warning shown");
     var notification = atom.notifications.addWarning(
       "Kite app missing", {
-      description: "Install the Kite app to get next-generation completions, documentation, and more.",
+      description: "Install Kite to get next-generation completions, documentation, and more.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -154,7 +154,7 @@ var Ready = {
     metrics.track("not-running warning shown");
     var notification = atom.notifications.addWarning(
       "Kite not running", {
-      description: "Start the Kite app to get Python completions and docs.",
+      description: "Start the Kite background service to get Python completions and docs.",
       icon: "circle-slash",
       dismissable: true,
       buttons: [{
@@ -200,7 +200,7 @@ var Ready = {
   warnNotReachable: function() {
     metrics.track("not-reachable warning shown");
     atom.notifications.addError(
-      "The Kite Menubar app is running but not reachable", {
+      "The Kite background service is running but not reachable", {
       description: "Try killing Kite from the Activity Monitor.",
       dismissable: true,
     }).onDidDismiss(() => {
@@ -321,8 +321,8 @@ var Ready = {
   notifyReady: function() {
     metrics.track("ready notification shown");
     atom.notifications.addSuccess(
-      "The Kite Menubar app is ready", {
-      description: "We checked that the Menubar app is installed, running, responsive, and authenticated.",
+      "The Kite background service is ready", {
+      description: "We checked that the background service is installed, running, responsive, and authenticated.",
       dismissable: true,
     }).onDidDismiss(() => {
       metrics.track("ready notification dismissed");


### PR DESCRIPTION
A few themes:

* Reframing from the Kite autocomplete daemon -> Kite Menubar app.  The thinking was 'daemon' sounds too technical, and we want to use common wording across e.g. the Menubar menu and these notifications.
* I tried to make the heading text shorter, and more like a title.
* My main concern was with the whitelist copy, which I made similar to what we currently have for that in the sidebar.