### PR TITLE
Add script to obfuscate all the js files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+public

--- a/obfuscate.sh
+++ b/obfuscate.sh
@@ -1,0 +1,27 @@
+cp package.json public/package.json;
+cp -R styles public/styles;
+cp -R keymaps public/keymaps;
+cp -R assets public/assets;
+
+function obfuscate {
+  echo "obfuscate ${1} to public/${1}"
+  if [[ "$1" = */* ]]; then
+    mkdir -p "public/${1%/*}";
+  fi;
+  touch public/${1};
+
+  javascript-obfuscator $1 \
+                        -o public/${1} \
+                        --compact false \
+                        --stringArray false \
+                        --disableConsoleOutput false \
+                        --reservedNames activate,deactivate,completions,consumeStatusBar;
+}
+
+for f in lib/*.js ; do
+  obfuscate $f;
+done
+
+for f in lib/**/*.js ; do
+  obfuscate $f;
+done

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "scripts": {
+    "obfuscate": "sh ./obfuscate.sh"
+  },
   "dependencies": {
     "kite-installer": "0.4.8",
     "mixpanel": "^0.5.0"
@@ -40,5 +43,8 @@
         "^1.0.0": "consumeStatusBar"
       }
     }
+  },
+  "devDependencies": {
+    "javascript-obfuscator": "^0.8.3"
   }
 }


### PR DESCRIPTION
It actually builds an obfuscated version of the whole package in a
`public` directory by copying all the other files (assets, keycaps,
styles).

For the moment the `public` must be created manually.