### PR TITLE
Don't display notification if Kite was uninstalled by the user

### DIFF
--- a/lib/ready.js
+++ b/lib/ready.js
@@ -83,6 +83,13 @@ var Ready = {
     var curpath = this.currentPath();
     StateController.handleState(curpath).then((state) => {
       this.updateStatusItem(state);
+
+      // when state is greater than or equal to STATES.INSTALLED we're sure
+      // kite have been installed once so we'll store that for later use.
+      if (state >= StateController.STATES.INSTALLED) {
+        localStorage.setItem('kite.wasInstalled', true)
+      }
+
       switch (state) {
         case StateController.STATES.UNSUPPORTED:
           if (this.shouldNotify(state) || forceNotify) {
@@ -178,28 +185,32 @@ var Ready = {
 
   warnNotInstalled: function() {
     var rejected = true;
-    metrics.track("not-installed warning shown");
-    var notification = atom.notifications.addWarning(
+    if (localStorage.getItem('kite.wasInstalled')) {
+      metrics.track("kite manually uninstalled - no notification");
+    } else {
+      metrics.track("not-installed warning shown");
+      var notification = atom.notifications.addWarning(
       "The Kite autocomplete engine is not installed", {
-      description: "Install Kite to get Python completions, documentation, and examples.",
-      icon: "circle-slash",
-      dismissable: true,
-      buttons: [{
-        text: "Install Kite",
-        onDidClick: () => {
-          rejected = false;  // so that onDidDismiss knows that this was not a reject
-          metrics.track("install button clicked (via not-installed warning)");
-          notification.dismiss();
-          this.install();
+        description: "Install Kite to get Python completions, documentation, and examples.",
+        icon: "circle-slash",
+        dismissable: true,
+        buttons: [{
+          text: "Install Kite",
+          onDidClick: () => {
+            rejected = false;  // so that onDidDismiss knows that this was not a reject
+            metrics.track("install button clicked (via not-installed warning)");
+            notification.dismiss();
+            this.install();
+          }
+        }]
+      });
+      notification.onDidDismiss(() => {
+        if (rejected) {
+          this.lastRejected[StateController.STATES.UNINSTALLED] = new Date();
+          metrics.track("not-installed warning dismissed");
         }
-      }]
-    });
-    notification.onDidDismiss(() => {
-      if (rejected) {
-        this.lastRejected[StateController.STATES.UNINSTALLED] = new Date();
-        metrics.track("not-installed warning dismissed");
-      }
-    });
+      });
+    }
   },
 
   install: function() {


### PR DESCRIPTION
Ref #21 

Note that if the user has set the autocomplete-python engine to kite, even if the notification don’t show up, the engine choice form still kicks in.