### PR TITLE
Allow to choose the root (homedir or /) or to pick a directory

### DIFF
--- a/lib/ready.js
+++ b/lib/ready.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const http = require('http');
 const path = require('path');
 const child_process = require('child_process');
@@ -482,28 +483,58 @@ var Ready = {
   warnNotWhitelisted: function(filepath) {
     var dir = path.dirname(filepath);
     var suggested =  findClosestGitRepo(dir) || dir;
-    var metricsInfo = {dir: dir, suggested: suggested};
-    metrics.track('not-whitelisted warning shown', metricsInfo);
+    var root = path.relative(os.homedir(), dir).indexOf('..') === 0
+      ? '/'
+      : os.homedir();
+    metrics.track('not-whitelisted warning shown', {dir,
+      suggested, root});
 
     var rejected = true;
     var notification = atom.notifications.addWarning(
       'The Kite autocomplete engine is disabled for ' + path.basename(filepath), {
-        description: 'Would you like to enable Kite for Python files in ' + suggested + '?',
+        description: 'Would you like to enable Kite for Python files in:',
         icon: 'circle-slash',
         dismissable: true,
         buttons: [{
-          text: 'Enable',
+          text: suggested,
+          className: 'block',
           onDidClick: () => {
             rejected = false;  // so that onDidDismiss knows that this was not a reject
-            metrics.track('enable button clicked (via not-whitelisted warning)', metricsInfo);
+            metrics.track('enable button clicked (via not-whitelisted warning)', {dir, suggested});
             notification.dismiss();
             this.whitelist(suggested);
+          },
+        }, {
+          text: root,
+          className: 'block',
+          onDidClick: () => {
+            rejected = false;  // so that onDidDismiss knows that this was not a reject
+            metrics.track('enable root button clicked (via not-whitelisted warning)', {dir, root});
+            notification.dismiss();
+            this.whitelist(root);
+          },
+        }, {
+          text: 'Browse...',
+          className: 'block',
+          onDidClick: () => {
+            rejected = false;  // so that onDidDismiss knows that this was not a reject
+            metrics.track('pick directory button clicked (via not-whitelisted warning)', {dir});
+            atom.applicationDelegate.pickFolder(p => {
+              if (p) {
+                metrics.track('directory picked (via not-whitelisted warning)', {dir: p});
+                notification.dismiss();
+                this.whitelist(root);
+              } else {
+                metrics.track('directory pick cancelled (via not-whitelisted warning)', {dir});
+              }
+            });
           },
         }],
       });
     notification.onDidDismiss(() => {
       if (rejected) {
-        metrics.track('not-whitelisted warning dismissed', metricsInfo);
+        metrics.track('not-whitelisted warning dismissed', {dir,
+          suggested, root});
         this.lastRejected[StateController.STATES.AUTHENTICATED] = new Date();
       }
     });

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -495,7 +495,7 @@ var Ready = {
         description: 'Would you like to enable Kite for Python files in:',
         icon: 'circle-slash',
         dismissable: true,
-        buttons: [{
+        buttons: [/*{
           text: suggested,
           className: 'block',
           onDidClick: () => {
@@ -504,32 +504,32 @@ var Ready = {
             notification.dismiss();
             this.whitelist(suggested);
           },
-        }, {
-          text: root,
-          className: 'block',
-          onDidClick: () => {
-            rejected = false;  // so that onDidDismiss knows that this was not a reject
-            metrics.track('enable root button clicked (via not-whitelisted warning)', {dir, root});
-            notification.dismiss();
-            this.whitelist(root);
-          },
-        }, {
-          text: 'Browse...',
-          className: 'block',
-          onDidClick: () => {
-            rejected = false;  // so that onDidDismiss knows that this was not a reject
-            metrics.track('pick directory button clicked (via not-whitelisted warning)', {dir});
-            atom.applicationDelegate.pickFolder(([p]) => {
-              if (p) {
-                metrics.track('directory picked (via not-whitelisted warning)', {dir: p});
-                notification.dismiss();
-                this.whitelist(root);
-              } else {
-                metrics.track('directory pick cancelled (via not-whitelisted warning)', {dir});
-              }
-            });
-          },
-        }],
+          }, */{
+            text: root,
+            className: 'block',
+            onDidClick: () => {
+              rejected = false;  // so that onDidDismiss knows that this was not a reject
+              metrics.track('enable root button clicked (via not-whitelisted warning)', {dir, root});
+              notification.dismiss();
+              this.whitelist(root);
+            },
+          }, {
+            text: 'Browse...',
+            className: 'block',
+            onDidClick: () => {
+              rejected = false;  // so that onDidDismiss knows that this was not a reject
+              metrics.track('pick directory button clicked (via not-whitelisted warning)', {dir});
+              atom.applicationDelegate.pickFolder(([p]) => {
+                if (p) {
+                  metrics.track('directory picked (via not-whitelisted warning)', {dir: p});
+                  notification.dismiss();
+                  this.whitelist(root);
+                } else {
+                  metrics.track('directory pick cancelled (via not-whitelisted warning)', {dir});
+                }
+              });
+            },
+          }],
       });
     notification.onDidDismiss(() => {
       if (rejected) {

--- a/lib/ready.js
+++ b/lib/ready.js
@@ -519,7 +519,7 @@ var Ready = {
           onDidClick: () => {
             rejected = false;  // so that onDidDismiss knows that this was not a reject
             metrics.track('pick directory button clicked (via not-whitelisted warning)', {dir});
-            atom.applicationDelegate.pickFolder(p => {
+            atom.applicationDelegate.pickFolder(([p]) => {
               if (p) {
                 metrics.track('directory picked (via not-whitelisted warning)', {dir: p});
                 notification.dismiss();


### PR DESCRIPTION
The notification now looks like this: 

<img width="492" alt="ready_js_ ___github_kite" src="https://cloud.githubusercontent.com/assets/247140/22116292/56116df8-de70-11e6-8dbc-275126b5708d.png">

When choosing `browse` the user is presented with a native dialog to pick a directory to whitelist.