### PR TITLE
Context menu

### DIFF
--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -2,10 +2,11 @@
 
 const {StateController, Logger} = require('kite-installer');
 const {
-  hoverPath, openDocumentationInWebURL, promisifyRequest,
-  promisifyReadResponse, head, valueReportPath, membersPath,
-  usagesPath, usagePath, examplePath, parseJSON,
-} = require('./utils');
+  hoverPath, openDocumentationInWebURL, valueReportPath, membersPath,
+  usagesPath, usagePath, examplePath,
+} = require('./urls');
+const {promisifyRequest, promisifyReadResponse, head, parseJSON} = require('./utils');
+
 const {MAX_FILE_SIZE} = require('./constants');
 const {symbolId} = require('./kite-data-utils');
 const VirtualCursor = require('./virtual-cursor');

--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -221,9 +221,12 @@ const DataLoader = {
     return StateController.isPathWhitelisted(editor.getPath())
     .then(() => this.getHoverDataAtRange(editor, range))
     .then(data => {
-      const id = symbolId(head(data.symbol));
-      atom.applicationDelegate.openExternal(openDocumentationInWebURL(id));
+      this.openInWebForId(symbolId(head(data.symbol)));
     });
+  },
+
+  openInWebForId(id) {
+    atom.applicationDelegate.openExternal(openDocumentationInWebURL(id));
   },
 };
 

--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -2,8 +2,14 @@
 
 const {StateController, Logger} = require('kite-installer');
 const {
-  hoverPath, openDocumentationInWebURL, valueReportPath, membersPath,
-  usagesPath, usagePath, examplePath,
+  examplePath,
+  hoverPath,
+  membersPath,
+  openDocumentationInWebURL,
+  tokensPath,
+  usagePath,
+  usagesPath,
+  valueReportPath,
 } = require('./urls');
 const {promisifyRequest, promisifyReadResponse, head, parseJSON} = require('./utils');
 
@@ -104,6 +110,19 @@ const DataLoader = {
       return data;
     })
     .catch(err => console.error(err));
+  },
+
+  getTokensForEditor(editor) {
+    const path = tokensPath(editor);
+    return promisifyRequest(StateController.client.request({path}))
+    .then(resp => {
+      Logger.logResponse(resp);
+      if (resp.statusCode !== 200) {
+        throw new Error(`${resp.statusCode} status at ${path}`);
+      }
+      return promisifyReadResponse(resp);
+    })
+    .then(data => parseJSON(data));
   },
 
   getHoverDataAtRange(editor, range) {

--- a/lib/elements/kite-curated-example.js
+++ b/lib/elements/kite-curated-example.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const _ = require('underscore-plus');
-const {last, head, openExampleInWebURL} = require('../utils');
+const {last, head} = require('../utils');
+const {openExampleInWebURL} = require('../urls');
 const {section, renderExample} = require('./html-utils');
 
 const escapeHTML = str =>

--- a/lib/elements/kite-expand-function.js
+++ b/lib/elements/kite-expand-function.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {openDocumentationInWebURL} = require('../utils');
+const {openDocumentationInWebURL} = require('../urls');
 const {renderValueHeader, renderExtend, renderUsages, renderParameters, renderExamples, renderDefinition, renderInvocations, valueDescription} = require('././html-utils');
 
 

--- a/lib/elements/kite-expand-instance.js
+++ b/lib/elements/kite-expand-instance.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {openDocumentationInWebURL} = require('../utils');
+const {openDocumentationInWebURL} = require('../urls');
 const {renderValueHeader, renderExtend, renderDefinition, renderUsages, valueDescription, renderExamples} = require('./html-utils');
 
 class KiteExpandInstance extends HTMLElement {

--- a/lib/elements/kite-expand-module.js
+++ b/lib/elements/kite-expand-module.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {openDocumentationInWebURL} = require('../utils');
+const {openDocumentationInWebURL} = require('../urls');
 const {renderValueHeader, renderExtend, renderExamples, renderUsages, renderDefinition, renderMembers, valueDescription} = require('./html-utils');
 
 class KiteExpandModule extends HTMLElement {

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const {CompositeDisposable} = require('atom');
+const {head} = require('./utils');
+const EditorEvents = require('./editor-events');
+const DataLoader = require('./data-loader');
+
+class KiteEditor {
+  constructor(editor) {
+    this.editor = editor;
+    this.buffer = editor.getBuffer();
+    this.editorElement = atom.views.getView(editor);
+    this.subscriptions = new CompositeDisposable();
+
+    this.subscriptions.add(new EditorEvents(editor));
+
+    this.subscriptions.add(editor.onDidStopChanging(() => {
+      this.updateTokens();
+    }));
+
+    this.updateTokens();
+  }
+
+  dispose() {
+    this.subscriptions && this.subscriptions.dispose();
+    delete this.subscriptions;
+    delete this.editorElement;
+    delete this.editor;
+    delete this.buffer;
+  }
+
+  updateTokens() {
+    DataLoader.getTokensForEditor(this.editor).then(tokens => {
+      this.tokens = tokens.tokens;
+      // console.log(this.tokens);
+    });
+  }
+
+  tokenAtPosition(position) {
+    const pos = this.buffer.characterIndexForPosition(position);
+    return this.tokens
+      ? head(this.tokens.filter(token => pos >= token.begin_bytes &&
+                                         pos <= token.end_bytes))
+      : null;
+  }
+
+  tokenForMouseEvent(event) {
+    const position = this.screenPositionForMouseEvent(event);
+
+    if (!position) { return null; }
+
+    const bufferPosition = this.editor.bufferPositionForScreenPosition(position);
+
+    return this.tokenAtPosition(bufferPosition);
+  }
+
+  screenPositionForMouseEvent(event) {
+    const pixelPosition = this.pixelPositionForMouseEvent(event);
+
+    if (pixelPosition == null) { return null; }
+
+    return this.editorElement.screenPositionForPixelPosition != null
+      ? this.editorElement.screenPositionForPixelPosition(pixelPosition)
+      : this.editor.screenPositionForPixelPosition(pixelPosition);
+  }
+
+  pixelPositionForMouseEvent(event) {
+    const {clientX, clientY} = event;
+
+    const scrollTarget = (this.editorElement.getScrollTop != null)
+      ? this.editorElement
+      : this.editor;
+
+    if (this.editorElement.querySelector('.lines') == null) { return null; }
+
+    let {top, left} = this.editorElement.querySelector('.lines').getBoundingClientRect();
+    top = (clientY - top) + scrollTarget.getScrollTop();
+    left = (clientX - left) + scrollTarget.getScrollLeft();
+    return {top, left};
+  }
+}
+
+module.exports = KiteEditor;

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -133,6 +133,7 @@ module.exports = {
       },
       'kite:open-in-web-from-menu': tokenMethod((event, token) => {
         DataLoader.openInWebForId(symbolId(token.Symbol));
+        metrics.track('Context menu Open in web clicked');
       }),
       'kite:expand-from-menu': tokenMethod((event, token, kiteEditor) => {
         const range = [
@@ -148,6 +149,7 @@ module.exports = {
         } else {
           OverlayManager.showExpandAtRange(kiteEditor.editor, range);
         }
+        metrics.track('Context menu See info clicked');
       }),
       'kite:go-to-definition-from-menu': tokenMethod((event, token) => {
         DataLoader.getValueReportDataForId(symbolId(token.Symbol))
@@ -162,6 +164,9 @@ module.exports = {
                 autoscroll: true,
               });
             });
+            metrics.track('Context menu Go to definition clicked (with definition in report)');
+          } else {
+            metrics.track('Context menu Go to definition clicked (without definition in report)');
           }
         })
         .catch(() => {});

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -197,10 +197,10 @@ module.exports = {
           label: 'Kite: Go to definition',
           command: 'kite:go-to-definition-from-menu',
           shouldDisplay,
-        }, {
-          label: 'Kite: Find Usages',
-          command: 'kite:find-usages-from-menu',
-          shouldDisplay,
+        // }, {
+        //   label: 'Kite: Find Usages',
+        //   command: 'kite:find-usages-from-menu',
+        //   shouldDisplay,
         },
       ],
     }));

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -19,8 +19,9 @@ const HoverGesture = require('./gestures/hover');
 const WordSelectionGesture = require('./gestures/word-selection');
 const CursorMoveGesture = require('./gestures/cursor-move');
 const OverlayManager = require('./overlay-manager');
-const EditorEvents = require('./editor-events');
+const KiteEditor = require('./kite-editor');
 const DataLoader = require('./data-loader');
+const {symbolId} = require('./kite-data-utils');
 
 module.exports = {
   activate() {
@@ -39,6 +40,7 @@ module.exports = {
     this.subscriptionsByEditorID = {};
     this.pathSubscriptionsByEditorID = {};
     this.whitelistedEditorIDs = {};
+    this.kiteEditorByEditorID = {};
 
     // send the activated event
     metrics.track('activated');
@@ -105,6 +107,12 @@ module.exports = {
     }));
 
     const Kite = this;
+    const tokenMethod = (action) => () => {
+      const editor = atom.workspace.getActiveTextEditor();
+      const kiteEditor = this.kiteEditorForEditor(editor);
+      const token = kiteEditor.tokenForMouseEvent(this.lastEvent);
+      action(this.lastEvent, token, kiteEditor);
+    };
 
     // Allow esc key to close expand view
     this.subscriptions.add(atom.commands.add('atom-text-editor[data-grammar="source python"]', {
@@ -123,12 +131,59 @@ module.exports = {
           DataLoader.openInWebAtPosition(editor, position);
         }
       },
+      'kite:open-in-web-from-menu': tokenMethod((event, token) => {
+        DataLoader.openInWebForId(symbolId(token.Symbol));
+      }),
+      'kite:expand-from-menu': tokenMethod((event, token, kiteEditor) => {
+        const range = [
+          kiteEditor.buffer.positionForCharacterIndex(token.begin_bytes),
+          kiteEditor.buffer.positionForCharacterIndex(token.end_bytes),
+        ];
+
+        if (this.expandDisplay === 'sidebar') {
+          if (!this.isSidebarVisible()) {
+            this.toggleSidebar(true);
+          }
+          this.sidebar.showDataAtRange(kiteEditor.editor, range);
+        } else {
+          OverlayManager.showExpandAtRange(kiteEditor.editor, range);
+        }
+      }),
+      'kite:go-to-definition-from-menu': tokenMethod((event, token) => {
+
+      }),
+      'kite:find-usages-from-menu': tokenMethod((event, token) => {
+
+      }),
     }));
 
     this.subscriptions.add(atom.commands.add('kite-sidebar', {
       'kite:open-in-web'() {
         this.openInWeb();
       },
+    }));
+
+    const shouldDisplay = e => this.shouldDisplayMenu(e);
+    this.subscriptions.add(atom.contextMenu.add({
+      'atom-text-editor': [
+        {
+          label: 'Kite: Open in Web',
+          command: 'kite:open-in-web-from-menu',
+          shouldDisplay,
+        }, {
+          label: 'Kite: See Info',
+          command: 'kite:expand-from-menu',
+          shouldDisplay,
+        }, {
+          label: 'Kite: Go to definition',
+          command: 'kite:go-to-definition-from-menu',
+          shouldDisplay,
+        }, {
+          label: 'Kite: Find Usages',
+          command: 'kite:find-usages-from-menu',
+          shouldDisplay,
+        },
+      ],
     }));
 
     this.subscriptions.add(atom.config.observe('kite.loggingLevel', (level) => {
@@ -324,6 +379,18 @@ module.exports = {
     return !!this.sidebar;
   },
 
+  shouldDisplayMenu(event) {
+    this.lastEvent = event;
+    setTimeout(() => delete this.lastEvent, 10);
+    return this.tokenForMouseEvent(event) != null;
+  },
+
+  tokenForMouseEvent(event) {
+    const editor = atom.workspace.getActiveTextEditor();
+    const kiteEditor = this.kiteEditorForEditor(editor);
+    return kiteEditor && kiteEditor.tokenForMouseEvent(event);
+  },
+
   getStatusItem() {
     if (this.status) { return this.status; }
 
@@ -339,6 +406,7 @@ module.exports = {
     // We don't want to subscribe twice to the same editor
     if (this.hasEditorSubscription(editor)) { return; }
 
+    const kiteEditor = new KiteEditor(editor);
     const expandGesture = new WordSelectionGesture(editor);
     const cursorGesture = new CursorMoveGesture(editor);
     const hoverGesture = new HoverGesture(editor, {
@@ -347,8 +415,9 @@ module.exports = {
     const subs = new CompositeDisposable();
     this.subscriptions.add(subs);
     this.subscriptionsByEditorID[editor.id] = subs;
+    this.kiteEditorByEditorID[editor.id] = kiteEditor;
 
-    subs.add(new EditorEvents(editor));
+    subs.add(kiteEditor);
     subs.add(hoverGesture);
     subs.add(expandGesture);
     subs.add(cursorGesture);
@@ -391,6 +460,11 @@ module.exports = {
     subs.dispose();
     this.subscriptions.remove(subs);
     delete this.subscriptionsByEditorID[editor.id];
+    delete this.kiteEditorByEditorID[editor.id];
+  },
+
+  kiteEditorForEditor(editor) {
+    return this.kiteEditorByEditorID[editor.id];
   },
 
   hasEditorSubscription(editor) {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -150,7 +150,21 @@ module.exports = {
         }
       }),
       'kite:go-to-definition-from-menu': tokenMethod((event, token) => {
-
+        DataLoader.getValueReportDataForId(symbolId(token.Symbol))
+        .then((data) => {
+          const {definition} = data.report;
+          if (definition) {
+            atom.workspace.open(definition.filename)
+            .then(editor => {
+              editor.setCursorBufferPosition([
+                definition.line - 1, 0,
+              ], {
+                autoscroll: true,
+              });
+            });
+          }
+        })
+        .catch(() => {});
       }),
       'kite:find-usages-from-menu': tokenMethod((event, token) => {
 

--- a/lib/overlay-manager.js
+++ b/lib/overlay-manager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {Emitter, CompositeDisposable} = require('atom');
+const {Range, Emitter, CompositeDisposable} = require('atom');
 const {Logger} = require('kite-installer');
 const {DisposableEvent} = require('./utils');
 const VirtualCursor = require('./virtual-cursor');
@@ -44,6 +44,7 @@ module.exports = {
     delete this.decoration;
     delete this.lastHoverRange;
     delete this.lastExpandRange;
+    delete this.expandDisplayed;
 
     this.emitter.emit('did-dismiss');
   },
@@ -77,7 +78,9 @@ module.exports = {
     this.dismissWithDelay();
 
     this.hoverTimeout = setTimeout(() => {
-      this.showHoverAtPosition(editor, position);
+      if (!this.expandDisplayed) {
+        this.showHoverAtPosition(editor, position);
+      }
     }, this.hoverDefault.show);
   },
 
@@ -91,6 +94,7 @@ module.exports = {
   },
 
   showHoverAtRange(editor, range) {
+    range = Range.fromObject(range);
     return this.enqueue(() => {
       if ((this.lastHoverRange && this.lastHoverRange.isEqual(range)) ||
           (this.lastExpandRange && this.lastExpandRange.isEqual(range))) {
@@ -133,6 +137,8 @@ module.exports = {
   },
 
   showExpandAtRange(editor, range) {
+    range = Range.fromObject(range);
+
     this.abortHoverWithDelay();
 
     return this.enqueue(() => {
@@ -179,6 +185,7 @@ module.exports = {
             break;
         }
         this.emitter.emit('did-show-expand');
+        this.expandDisplayed = true;
       })
       .catch(err => Logger.error(err));
     });

--- a/lib/rollbar-reporter.js
+++ b/lib/rollbar-reporter.js
@@ -21,8 +21,10 @@ require('rollbar-browser');
 class RollbarReporter {
   constructor() {
     this.subscription = atom.onDidThrowError(({column, line, message, originalError, url}) => {
-      // We're only concerned by errors that originate or involve our code.
-      if (/\/kite\/|\/kite-installer\//.test(originalError.stack)) {
+      // We're only concerned by errors that originate or involve our code
+      // but not when working on it.
+      if (/\/kite\/|\/kite-installer\//.test(originalError.stack) &&
+          !/kite$/.test(atom.project.getPaths()[0] || '')) {
         window.Rollbar.error(originalError);
       }
     });

--- a/lib/urls.js
+++ b/lib/urls.js
@@ -1,0 +1,110 @@
+'use strict';
+const md5 = require('md5');
+const {Range} = require('atom');
+const {head} = require('./utils');
+const {StateController} = require('kite-installer');
+
+
+function tokensPath(editor) {
+  const state = md5(editor.getText());
+  const filename = editor.getPath();
+  const buffer = cleanPath(filename);
+  return [
+    `/api/buffer/atom/${buffer}/${state}/tokens`,
+    `localtoken=${StateController.client.LOCAL_TOKEN}`,
+  ].join('?');
+}
+
+function reportPath(data) {
+  const value = head(head(data.symbol).value);
+
+  return valueReportPath(value.id);
+}
+
+function valueReportPath(id) {
+  return [
+    `/api/editor/value/${id}`,
+    `localtoken=${StateController.client.LOCAL_TOKEN}`,
+  ].join('?');
+}
+
+function membersPath(id, page = 0, limit = 999) {
+  return [
+    `/api/editor/value/${id}/members`,
+    [
+      `offset=${page}`,
+      `limit=${limit}`,
+      `localtoken=${StateController.client.LOCAL_TOKEN}`,
+    ].join('&'),
+  ].join('?');
+}
+
+function usagesPath(id, page = 0, limit = 999) {
+  return [
+    `/api/editor/value/${id}/usages`,
+    [
+      `offset=${page}`,
+      `limit=${limit}`,
+      `localtoken=${StateController.client.LOCAL_TOKEN}`,
+    ].join('&'),
+  ].join('?');
+}
+
+function usagePath(id) {
+  return [
+    `/api/editor/usages/${id}`,
+    `localtoken=${StateController.client.LOCAL_TOKEN}`,
+  ].join('?');
+}
+
+function examplePath(id) {
+  return [
+    `/api/python/curation/${id}`,
+    `localtoken=${StateController.client.LOCAL_TOKEN}`,
+  ].join('?');
+}
+
+function openDocumentationInWebURL(id) {
+  const token = StateController.client.LOCAL_TOKEN;
+  return `http://localhost:46624/clientapi/desktoplogin?d=/docs/python/${id}&localtoken=${token}`;
+}
+
+function openExampleInWebURL(id) {
+  const token = StateController.client.LOCAL_TOKEN;
+  return `http://localhost:46624/clientapi/desktoplogin?d=/examples/${id}&localtoken=${token}`;
+}
+
+function hoverPath(editor, range) {
+  range = Range.fromObject(range);
+
+  const state = md5(editor.getText());
+  const filename = editor.getPath();
+  const buffer = cleanPath(filename);
+  const start = editor.getBuffer().characterIndexForPosition(range.start);
+  const end = editor.getBuffer().characterIndexForPosition(range.end);
+  return [
+    `/api/buffer/atom/${buffer}/${state}/hover`,
+    [
+      `selection_begin_bytes=${start}`,
+      `selection_end_bytes=${end}`,
+      `localtoken=${StateController.client.LOCAL_TOKEN}`,
+    ].join('&'),
+  ].join('?');
+}
+
+function cleanPath(p) {
+  return p.replace(/^([A-Z]):/, '/windows/$1').replace(/\/|\\/g, ':');
+}
+
+module.exports = {
+  examplePath,
+  hoverPath,
+  membersPath,
+  openDocumentationInWebURL,
+  openExampleInWebURL,
+  reportPath,
+  tokensPath,
+  usagePath,
+  usagesPath,
+  valueReportPath,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const md5 = require('md5');
-const {Range, Disposable} = require('atom');
-const {StateController} = require('kite-installer');
+const { Disposable} = require('atom');
 
 const compact = a => a.filter(v => v && v !== '');
 
@@ -121,97 +119,6 @@ function parseJSON(data, fallback) {
   }
 }
 
-function tokensPath(editor) {
-  const state = md5(editor.getText());
-  const filename = editor.getPath();
-  const buffer = cleanPath(filename);
-  return [
-    `/api/buffer/atom/${buffer}/${state}/tokens`,
-    `localtoken=${StateController.client.LOCAL_TOKEN}`,
-  ].join('?');
-}
-
-function reportPath(data) {
-  const value = head(head(data.symbol).value);
-
-  return valueReportPath(value.id);
-}
-
-function valueReportPath(id) {
-  return [
-    `/api/editor/value/${id}`,
-    `localtoken=${StateController.client.LOCAL_TOKEN}`,
-  ].join('?');
-}
-
-function membersPath(id, page = 0, limit = 999) {
-  return [
-    `/api/editor/value/${id}/members`,
-    [
-      `offset=${page}`,
-      `limit=${limit}`,
-      `localtoken=${StateController.client.LOCAL_TOKEN}`,
-    ].join('&'),
-  ].join('?');
-}
-
-function usagesPath(id, page = 0, limit = 999) {
-  return [
-    `/api/editor/value/${id}/usages`,
-    [
-      `offset=${page}`,
-      `limit=${limit}`,
-      `localtoken=${StateController.client.LOCAL_TOKEN}`,
-    ].join('&'),
-  ].join('?');
-}
-
-function usagePath(id) {
-  return [
-    `/api/editor/usages/${id}`,
-    `localtoken=${StateController.client.LOCAL_TOKEN}`,
-  ].join('?');
-}
-
-function examplePath(id) {
-  return [
-    `/api/python/curation/${id}`,
-    `localtoken=${StateController.client.LOCAL_TOKEN}`,
-  ].join('?');
-}
-
-function openDocumentationInWebURL(id) {
-  const token = StateController.client.LOCAL_TOKEN;
-  return `http://localhost:46624/clientapi/desktoplogin?d=/docs/python/${id}&localtoken=${token}`;
-}
-
-function openExampleInWebURL(id) {
-  const token = StateController.client.LOCAL_TOKEN;
-  return `http://localhost:46624/clientapi/desktoplogin?d=/examples/${id}&localtoken=${token}`;
-}
-
-function hoverPath(editor, range) {
-  range = Range.fromObject(range);
-
-  const state = md5(editor.getText());
-  const filename = editor.getPath();
-  const buffer = cleanPath(filename);
-  const start = editor.getBuffer().characterIndexForPosition(range.start);
-  const end = editor.getBuffer().characterIndexForPosition(range.end);
-  return [
-    `/api/buffer/atom/${buffer}/${state}/hover`,
-    [
-      `selection_begin_bytes=${start}`,
-      `selection_end_bytes=${end}`,
-      `localtoken=${StateController.client.LOCAL_TOKEN}`,
-    ].join('&'),
-  ].join('?');
-}
-
-function cleanPath(p) {
-  return p.replace(/^([A-Z]):/, '/windows/$1').replace(/\/|\\/g, ':');
-}
-
 // get time in seconds since the date
 function secondsSince(when) {
   var now = new Date();
@@ -242,28 +149,18 @@ module.exports = {
   DisposableEvent,
   eachParent,
   editorRoot,
-  examplePath,
   flatten,
   head,
-  hoverPath,
   last,
   log,
-  membersPath,
   nodeAndParents,
   noShadowDOM,
-  openDocumentationInWebURL,
-  openExampleInWebURL,
   parent,
   parents,
   parseJSON,
   promisifyReadResponse,
   promisifyRequest,
-  reportPath,
   secondsSince,
-  tokensPath,
   truncate,
   uniq,
-  usagePath,
-  usagesPath,
-  valueReportPath,
 };

--- a/spec/fixtures/sample.py
+++ b/spec/fixtures/sample.py
@@ -15,7 +15,6 @@ json.dumps
 posix.chmod
 os.mkdir
 csv.reader
-
 matplotlib.pyplot.plot
 
 class A:

--- a/spec/overlay-manager-spec.js
+++ b/spec/overlay-manager-spec.js
@@ -5,7 +5,7 @@ const path = require('path');
 const http = require('http');
 const KiteApp = require('../lib/kite-app');
 const OverlayManager = require('../lib/overlay-manager');
-const {hoverPath} = require('../lib/utils');
+const {hoverPath} = require('../lib/urls');
 const {
   withKiteWhitelistedPaths, withRoutes, fakeResponse,
 } = require('./spec-helpers');


### PR DESCRIPTION
Implement contextual menu for tokens:

- [x] Open in web
- [x] See info (aka show expand UI)
- [x] Go to definition
  - Partial support. Given that we have to hit the report endpoint to get the definition we can't be sure we'll have a definition to go to.
- [ ] Usages
  - As of today (version of the 15-02) I still get 404 for every requests I make to this endpoint so the menu still does nothing. 
