### PR TITLE
Gate common invocations

### DIFF
--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -45,7 +45,7 @@ class KiteSignature extends HTMLElement {
     if (!compact) {
       let patterns = '';
       if (call.signatures && call.signatures.length) {
-        patterns = Plan.can('call_signatures_editor')
+        patterns = Plan.can('common_invocations_editor')
           ? `
             <section>
             <h4>Popular Patterns</h4>


### PR DESCRIPTION
@abe33 this pr makes a slight modification to the gating for the common invocations section. 

All users are allowed to see the call signature and this is indicated via the `call_signatures_*` flags. 

Only pro users are allowed to see the "Popular Patterns" section and this is indicated via the `common_invocations_*` flags.

Sorry for all the thrashing around this! We changed the naming up last Friday, I have accidentally been referring to this as "Call Signatures" in the docs, my bad! I have updated all of the relevant docs! 