### PR TITLE
Fix access to id when rendering additional examples link

### DIFF
--- a/lib/elements/html-utils.js
+++ b/lib/elements/html-utils.js
@@ -179,9 +179,20 @@ function renderExample(example) {
 }
 
 function additionalExamplesLink(examplesCount, data) {
+  const id = data.value
+    ? data.value.id
+    : (
+      data.symbol.id
+        ? data.symbol.id
+        : (
+          data.symbol.value.id
+            ? data.symbol.value.id
+            : data.symbol.value[0].id
+        )
+    );
   return examplesCount <= 0
     ? ''
-    : `<a href="kite-atom-internal://examples-list/${data.value ? data.value.id : data.symbol.id}"
+    : `<a href="kite-atom-internal://examples-list/${id}"
           class="more-examples">See ${examplesCount} more examples</a>`;
 }
 


### PR DESCRIPTION
This is a bit convoluted of a solution, but it should cover pretty much all cases, as a quick patch. I'll look for a nicer solution later.

Ref #261