### PR TITLE
Implement kited health segment metrics

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -309,6 +309,10 @@ module.exports = {
       }
     }, atom.config.get('kite.pollingInterval'));
 
+    // We monitor kited health
+    setInterval(checkHealth, 60 * 1000 * 10);
+    checkHealth();
+
     // We try to connect at startup
     return this.app.connectWithLanguages().then(state => {
       if (state === KiteApp.STATES.UNSUPPORTED) {
@@ -327,6 +331,19 @@ module.exports = {
         this.checkTextEditor(atom.workspace.getActiveTextEditor());
       }
     });
+
+    function checkHealth() {
+      StateController.handleState().then(state => {
+        switch (state) {
+          case 0: return metrics.trackHealth('unsupported');
+          case 1: return metrics.trackHealth('uninstalled');
+          case 2: return metrics.trackHealth('installed');
+          case 3: return metrics.trackHealth('running');
+          case 4: return metrics.trackHealth('reachable');
+          case 5: return metrics.trackHealth('authenticated');
+        }
+      });
+    }
   },
 
   connect() {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -5,10 +5,21 @@ const crypto = require('crypto');
 const {Logger, StateController} = require('kite-installer');
 const {metricsCounterPath} = require('./urls');
 const localconfig = require('./localconfig.js');
+const Segment = require('analytics-node');
+
+const version = require('../package.json').version;
 
 const OS_VERSION = os.type() + ' ' + os.release();
 
 const EDITOR_UUID = localStorage.getItem('metrics.userId');
+
+// Dev Segment: lKUjCVUmzSpxblG611Dr6pct8fu7ty9W
+// Prod Segment: 9ZGfMQ24THOg69yIyZRPJ1GTJ9RsBlFK
+
+const ANALYTICS = new Segment(
+  atom.inDevMode()
+  ? 'lKUjCVUmzSpxblG611Dr6pct8fu7ty9W'
+  : '9ZGfMQ24THOg69yIyZRPJ1GTJ9RsBlFK');
 
 // Generate a unique ID for this user and save it for future use.
 function distinctID() {
@@ -41,14 +52,47 @@ function sendFeatureMetric(name) {
 function featureRequested(name) {
   sendFeatureMetric(`atom_${name}_requested`);
 }
+
 function featureFulfilled(name) {
   sendFeatureMetric(`atom_${name}_fulfilled`);
+}
+
+function track(event, props = {}) {
+  const e = {
+    event,
+    userId: '0',
+    user_id: distinctID(),
+    sent_at: Math.floor(new Date().getTime() / 1000),
+    source: 'atom',
+  };
+
+  for (const k in props) { e[k] = props[k]; }
+
+  if (!atom.inSpecMode()) { ANALYTICS.track(e); }
+}
+
+function trackHealth(value) {
+  track('kited_health', {
+    value,
+    os_name: getOsName(),
+    plugin_version: version,
+  });
+}
+
+function getOsName() {
+  switch (os.platform()) {
+    case 'darwin': return 'macos';
+    case 'win32': return 'windows';
+    default: return '';
+  }
 }
 
 module.exports = {
   distinctID,
   featureRequested,
   featureFulfilled,
+  track,
+  trackHealth,
   EDITOR_UUID,
   OS_VERSION,
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -71,7 +71,7 @@ function track(event, properties = {}) {
     properties,
   };
 
-  if (!atom.inSpecMode()) { ANALYTICS.track(e); }
+  if (!atom.inSpecMode() && macaddress) { ANALYTICS.track(e); }
 }
 
 function trackHealth(value) {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -32,6 +32,13 @@ function distinctID() {
   return id;
 }
 
+let macaddress;
+
+require('getmac').getMac((err, mac) => {
+  if (err) { throw err; }
+  macaddress = mac;
+});
+
 function sendFeatureMetric(name) {
   const path = metricsCounterPath();
 
@@ -69,7 +76,7 @@ function track(event, properties = {}) {
 
 function trackHealth(value) {
   track('kited_health', {
-    user_id: distinctID(),
+    user_id: macaddress,
     sent_at: Math.floor(new Date().getTime() / 1000),
     source: 'atom',
     value,

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -57,22 +57,21 @@ function featureFulfilled(name) {
   sendFeatureMetric(`atom_${name}_fulfilled`);
 }
 
-function track(event, props = {}) {
+function track(event, properties = {}) {
   const e = {
     event,
     userId: '0',
-    user_id: distinctID(),
-    sent_at: Math.floor(new Date().getTime() / 1000),
-    source: 'atom',
+    properties,
   };
-
-  for (const k in props) { e[k] = props[k]; }
 
   if (!atom.inSpecMode()) { ANALYTICS.track(e); }
 }
 
 function trackHealth(value) {
   track('kited_health', {
+    user_id: distinctID(),
+    sent_at: Math.floor(new Date().getTime() / 1000),
+    source: 'atom',
     value,
     os_name: getOsName(),
     plugin_version: version,

--- a/package.json
+++ b/package.json
@@ -117,12 +117,13 @@
     }
   },
   "dependencies": {
+    "analytics-node": "^3.1.1",
     "element-resize-detector": "^1.1.11",
     "fuzzaldrin-plus": "^0.4.1",
     "kite-installer": "^0.23.2",
     "md5": "^2.2.0",
-    "underscore-plus": "^1",
-    "rollbar-browser": "1.9.3"
+    "rollbar-browser": "1.9.3",
+    "underscore-plus": "^1"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "kite-installer": "^0.23.2",
     "md5": "^2.2.0",
     "rollbar-browser": "1.9.3",
-    "underscore-plus": "^1"
+    "underscore-plus": "^1",
+    "getmac": "^1.2.1"
   },
   "devDependencies": {
     "babel-eslint": "^6.1.2",


### PR DESCRIPTION
This PR implements the `kited_health` metric sent to Segment. 

The switch between development and production mode is done using the `inDevMode` helper of the Atom APIs. 

No events are sent when running tests.

The `userId` field can't be `0` as it seems the nodejs lib is validating it, `'0'` makes the validation pass.

