### PR TITLE
Use the current editor cursor position instead of the provided one

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -34,18 +34,22 @@ const KiteProvider = {
       if (!Kite) { Kite = require('./kite'); }
 
       return promise.then(() =>
-      DataLoader.getCompletionsAtPosition(params.editor, params.bufferPosition));
+      DataLoader.getCompletionsAtPosition(params.editor, params.editor.getCursorBufferPosition()));
     }, 0);
   },
 
   isInsideFunctionCall({scopeDescriptor}) {
-    return scopeDescriptor.scopes.some(s => s.indexOf('function-call') !== -1);
+    return scopeDescriptor.scopes.some(s =>
+      s.indexOf('function-call') !== -1 ||
+      s.indexOf('method-call') !== -1 ||
+      s.indexOf('arguments') !== -1
+    );
   },
 
-  loadSignature({editor, bufferPosition}) {
+  loadSignature({editor}) {
     const compact = false;
 
-    return DataLoader.getSignaturesAtPosition(editor, bufferPosition)
+    return DataLoader.getSignaturesAtPosition(editor, editor.getCursorBufferPosition())
     .then(data => {
       if (data) {
         const listElement = this.getSuggestionsListElement( );


### PR DESCRIPTION
Apparently there's an issue with bracket matcher that makes the position
we receive in the autocomplete-plus provider invalid.