### PR TITLE
Remove signature def link

### DIFF
--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -90,7 +90,6 @@ class KiteSignature extends HTMLElement {
       }
 
       const actions = [
-        `<a href="${internalGotoIdURL(call.callee.id)}">def</a>`,
         `<a is="kite-localtoken-anchor"
            href="${openSignatureInWebURL(call.callee.id)}">web</a>`,
         `<a href="${internalExpandURL(call.callee.id)}">more</a>`,


### PR DESCRIPTION
As Atom was the only editor to show it and we're not sure at the moment if we should display the linkor not.