### PR TITLE
Make save validation and autocorrect requests concurrent

### DIFF
--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -109,40 +109,41 @@ class KiteEditor {
 
     const requestStartTime = new Date();
 
-    return DataLoader.postSaveValidationData(this.editor)
-    .then(() => DataLoader.getAutocorrectData(this.editor))
-    .then(data => {
-      const hash = md5(this.editor.getText());
-      const status = Kite.getAutocorrectStatusItem();
+    return Promise.all([
+      DataLoader.postSaveValidationData(this.editor),
+      DataLoader.getAutocorrectData(this.editor)
+      .then(data => {
+        const hash = md5(this.editor.getText());
+        const status = Kite.getAutocorrectStatusItem();
 
-      if (data.requested_buffer_hash !== hash) {
-        status.textContent = '';
-        DataLoader.postAutocorrectHashMismatchData(data, requestStartTime);
-        return;
-      }
-
-      const fixes = data.diffs ? data.diffs.length : 0;
-
-      this.lastCorrectionsData = data;
-
-      if (fixes > 0) {
-        this.buffer.setTextViaDiff(data.new_buffer);
-        this.fixesHistory.unshift(new Fix(data.diffs));
-
-        if (atom.config.get('kite.openAutocorrectSidebarOnSave') &&
-           !Kite.isAutocorrectSidebarVisible()) {
-          Kite.toggleAutocorrectSidebar(true);
-        } else if (Kite.isAutocorrectSidebarVisible()) {
-          Kite.autocorrectSidebar.renderDiffs(Kite.autocorrectSidebar.getCurrentEditorCorrectionsHistory());
+        if (data.requested_buffer_hash !== hash) {
           status.textContent = '';
-        } else {
-          status.textContent = `${fixes} ${fixes === 1 ? 'error' : 'errors'} fixed`;
+          DataLoader.postAutocorrectHashMismatchData(data, requestStartTime);
+          return;
         }
-      } else {
-        status.textContent = '';
-      }
-    })
-    .catch(() => {});
+
+        const fixes = data.diffs ? data.diffs.length : 0;
+
+        this.lastCorrectionsData = data;
+
+        if (fixes > 0) {
+          this.buffer.setTextViaDiff(data.new_buffer);
+          this.fixesHistory.unshift(new Fix(data.diffs));
+
+          if (atom.config.get('kite.openAutocorrectSidebarOnSave') &&
+             !Kite.isAutocorrectSidebarVisible()) {
+            Kite.toggleAutocorrectSidebar(true);
+          } else if (Kite.isAutocorrectSidebarVisible()) {
+            Kite.autocorrectSidebar.renderDiffs(Kite.autocorrectSidebar.getCurrentEditorCorrectionsHistory());
+            status.textContent = '';
+          } else {
+            status.textContent = `${fixes} ${fixes === 1 ? 'error' : 'errors'} fixed`;
+          }
+        } else {
+          status.textContent = '';
+        }
+      }),
+    ]).catch(() => {});
   }
 
   updateTokens() {


### PR DESCRIPTION
The changes look complex but in practice the only significant change is to return a `Promise.all` instead of chaining the autocorrect request after the save validation one.