### PR TITLE
Fix for false positive notifications

### DIFF
--- a/lib/elements/kite-status.js
+++ b/lib/elements/kite-status.js
@@ -81,7 +81,7 @@ class KiteStatus extends HTMLElement {
   subscribe() {
     this.subscriptions = this.subscriptions || new CompositeDisposable();
 
-    this.subscriptions.add(this.app.onDidGetState(state => {
+    this.subscriptions.add(this.app.onDidGetState(({ state }) => {
       if (this.updateOnGetState) {
         this.setState(state, this.app.hasActiveSupportedFile());
       }

--- a/lib/kite-app.js
+++ b/lib/kite-app.js
@@ -170,10 +170,9 @@ class KiteApp {
     this.emitter.dispose();
   }
 
-  connect() {
+  connect(src) {
     ensureKiteDeps();
     if (!Plan) { Plan = require('./plan'); }
-
     return StateController.handleState().then(state => {
       if (state >= StateController.STATES.INSTALLED) {
         localStorage.setItem('kite.wasInstalled', true);
@@ -187,7 +186,19 @@ class KiteApp {
         );
       }
 
-      this.emitter.emit('did-get-state', state);
+      //hack around false positive login notifications
+      //basic idea is to create a 'canNotify' predicate based on the source of the connect
+      //call and a comparison between a current polled state and a previous one
+      let canNotify = false;
+      if (state === StateController.STATES.RUNNING || state === StateController.STATES.REACHABLE) {
+        if ((this.previousPolledState && this.previousPolledState === state) && 
+              (src === 'activation' || src === 'pollingInterval')) {
+          canNotify = true;
+        }
+      } else { 
+        canNotify = true;
+      }
+      this.emitter.emit('did-get-state', { state, canNotify });
 
       if (state !== this.previousState) {
         this.emitter.emit('did-change-state', state);
@@ -198,6 +209,10 @@ class KiteApp {
           this.ready = true;
         }
       }
+      //only set this.previousPolledState under certain callers of connect
+      if (src === 'activation' || src === 'pollingInterval') {
+        this.previousPolledState = state;
+      }
 
       return state >= StateController.STATES.REACHABLE
         ? Plan.queryPlan().then(() => state) :
@@ -205,10 +220,10 @@ class KiteApp {
     });
   }
 
-  connectWithLanguages() {
+  connectWithLanguages(src) {
     if (!DataLoader) { DataLoader = require('./data-loader'); }
 
-    return this.connect().then(state => {
+    return this.connect(src).then(state => {
       if (state >= StateController.STATES.REACHABLE) {
         return DataLoader.getSupportedLanguages()
         .then(languages => [state, languages])

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -126,17 +126,17 @@ module.exports = {
 
     // Whenever an action is accomplished through the kite app
     // we need to check again the state of the app
-    this.subscriptions.add(this.app.onDidInstall(() => this.connect()));
+    this.subscriptions.add(this.app.onDidInstall(() => this.connect('onDidInstall')));
 
-    this.subscriptions.add(this.app.onDidStart(() => this.connect()));
+    this.subscriptions.add(this.app.onDidStart(() => this.connect('onDidStart')));
 
     this.subscriptions.add(this.app.onDidAuthenticate(() => {
-      this.connect();
+      this.connect('onDidAuthenticate');
       // this.app.saveUserID();
     }));
 
     this.subscriptions.add(this.app.onDidWhitelist(() => {
-      this.connect();
+      this.connect('onDidWhitelist');
       // this.app.saveUserID();
     }));
 
@@ -406,9 +406,9 @@ module.exports = {
 
     this.pollingInterval = setInterval(() => {
       if (atom.workspace.getActiveTextEditor()) {
-        this.checkTextEditor(atom.workspace.getActiveTextEditor());
+        this.checkTextEditor(atom.workspace.getActiveTextEditor(), 'pollingInterval');
       } else {
-        this.connect();
+        this.connect('pollingInterval');
       }
     }, atom.config.get('kite.pollingInterval'));
 
@@ -421,7 +421,7 @@ module.exports = {
     }
 
     // We try to connect at startup
-    this.app.connectWithLanguages().then(state => {
+    this.app.connectWithLanguages('activation').then(state => {
       if (state === KiteApp.STATES.UNSUPPORTED) {
         if (!StateController.isOSSupported()) {
         } else if (!StateController.isOSVersionSupported()) {
@@ -455,8 +455,8 @@ module.exports = {
     }
   },
 
-  connect() {
-    return this.app.connect();
+  connect(src) {
+    return this.app.connect(src);
   },
 
   registerEditorEvents(editor) {
@@ -470,9 +470,11 @@ module.exports = {
     }
   },
 
-  checkTextEditor(editor) {
+  checkTextEditor(editor, src) {
     this.registerEditorEvents(editor);
-    const check = (editor) => this.app.connect().then(state => {
+    //src and from act to pass into connect the named of the context in which
+    //the function was called, so that connect can handle error state appropriately
+    const check = (editor, from) => this.app.connect(from).then(state => {
       const supported = this.app.isGrammarSupported(editor);
       // we only subscribe to the editor if it's a
       // python file and we're authenticated
@@ -519,9 +521,8 @@ module.exports = {
       sub.add(editor.onDidDestroy(() => dispose()));
       this.pathSubscriptionsByEditorID[editor.id] = sub;
     }
-
     return editor.getPath()
-      ? check(editor)
+      ? check(editor, src)
       : Promise.reject();
   },
 

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -45,8 +45,8 @@ class NotificationsCenter {
     this.subscriptions = new CompositeDisposable();
     this.lastShown = {};
 
-    this.subscriptions.add(app.onDidGetState(state => {
-      if (this.shouldNotify(state)) { this.notify(state); }
+    this.subscriptions.add(app.onDidGetState(({ state, canNotify }) => {
+      if (canNotify && this.shouldNotify(state)) { this.notify(state); }
     }));
 
     this.subscriptions.add(app.onDidGetUnauthorized(err => {
@@ -397,10 +397,10 @@ class NotificationsCenter {
       }));
   }
 
-  shouldNotify(key) {
+  shouldNotify(state) {
     return this.forceNotification ||
           ((this.app && this.app.hasActiveSupportedFile()) &&
-           !this.lastShown[key] &&
+           !this.lastShown[state] &&
            !this.paused);
   }
 

--- a/spec/notifications-center-spec.js
+++ b/spec/notifications-center-spec.js
@@ -542,10 +542,11 @@ describe('NotificationsCenter', () => {
 
       withKiteNotReachable(() => {
         beforeEach(() => {
-          waitsForPromise(() => app.connect().then(() => {
+          waitsForPromise(() => app.connect('pollingInterval')
+          .then(() => app.connect('pollingInterval'))
+          .then(() => {
             notificationElement = getNotificationElement();
             notification = notificationElement.getModel();
-
           }));
         });
 
@@ -597,7 +598,9 @@ describe('NotificationsCenter', () => {
 
         describe('when no login form is present', () => {
           beforeEach(() => {
-            waitsForPromise(() => app.connect().then(() => {
+            waitsForPromise(() => app.connect('pollingInterval')
+            .then(() => app.connect('pollingInterval'))  
+            .then(() => {
               notificationElement = getNotificationElement();
               notification = notificationElement.getModel();
             }));


### PR DESCRIPTION
When kited restarts (due to an update or whatever) and Atom is running, Atom will continue to poll kited. There are gaps between when kited starts, when it has registered all of its handlers, and lastly when it has restored the user ref from a previous session, should one exist. The user-facing effect are confusing false notifications of Kite state
This PR creates logic to only show `REACHABLE` and `RUNNING` notifications after the state has been confirmed by a re-poll, in order to allow kited sufficient time