### PR TITLE
Remove render of SO links in sidebar

### DIFF
--- a/lib/elements/kite-expand-function.js
+++ b/lib/elements/kite-expand-function.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {openDocumentationInWebURL} = require('../urls');
-const {renderSymbolHeader, renderExtend, renderUsages, renderParameters, renderExamples, renderDefinition, renderInvocations, debugData, renderLinks, renderReturnType, renderDocs} = require('./html-utils');
+const {renderSymbolHeader, renderExtend, renderUsages, renderParameters, renderExamples, renderDefinition, renderInvocations, debugData, renderReturnType, renderDocs} = require('./html-utils');
 const {idIsEmpty} = require('../kite-data-utils');
 const {renderPatterns, renderLanguageSpecificArguments} = require('./function-utils');
 const KiteExpandPanel = require('./kite-expand-panel');
@@ -29,7 +29,6 @@ class KiteExpandFunction extends KiteExpandPanel {
         ${renderUsages(data)}
         ${renderExamples(data)}
         ${renderDefinition(data)}
-        ${renderLinks(data)}
         ${renderInvocations(value)}
         ${debugData(data)}
       </div>

--- a/lib/elements/kite-expand-instance.js
+++ b/lib/elements/kite-expand-instance.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {openDocumentationInWebURL} = require('../urls');
-const {renderSymbolHeader, renderExtend, renderDefinition, renderUsages, renderDocs, renderExamples, debugData, renderLinks} = require('./html-utils');
+const {renderSymbolHeader, renderExtend, renderDefinition, renderUsages, renderDocs, renderExamples, debugData} = require('./html-utils');
 const {idIsEmpty} = require('../kite-data-utils');
 const KiteExpandPanel = require('./kite-expand-panel');
 
@@ -23,7 +23,6 @@ class KiteExpandInstance extends KiteExpandPanel {
         ${renderUsages(data)}
         ${renderExamples(data)}
         ${renderDefinition(symbol)}
-        ${renderLinks(data)}
         ${debugData(data)}
       </div>
     </div>

--- a/lib/elements/kite-expand-module.js
+++ b/lib/elements/kite-expand-module.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {openDocumentationInWebURL} = require('../urls');
-const {renderSymbolHeader, renderExtend, renderExamples, renderUsages, renderDefinition, renderMembers, renderDocs, debugData, renderLinks, renderParameters} = require('./html-utils');
+const {renderSymbolHeader, renderExtend, renderExamples, renderUsages, renderDefinition, renderMembers, renderDocs, debugData, renderParameters} = require('./html-utils');
 const {idIsEmpty} = require('../kite-data-utils');
 const {renderPatterns, renderLanguageSpecificArguments} = require('./function-utils');
 const KiteExpandPanel = require('./kite-expand-panel');
@@ -32,7 +32,6 @@ class KiteExpandModule extends KiteExpandPanel {
         ${renderUsages(data)}
         ${renderExamples(data)}
         ${renderDefinition(data)}
-        ${renderLinks(data)}
         ${debugData(data)}
       </div>
     </div>


### PR DESCRIPTION
Closes #332 

Just like the VSCode version, the HTML helpers and styles are still present, let me know if I should remove them.