### PR TITLE
Remove legacy sidebar implementation in favor of the dock API

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -39,11 +39,7 @@ class KiteAutocorrectSidebar extends HTMLElement {
 
   createdCallback() {
     this.innerHTML = `
-      <div class="kite-sidebar-resizer"></div>
       <div class="kite-column">
-        <header>
-          <button class="btn icon icon-x"></button>
-        </header>
         <div class="content"></div>
         <footer>
           <label>
@@ -54,16 +50,12 @@ class KiteAutocorrectSidebar extends HTMLElement {
       </div>
     `;
 
-    this.closeBtn = this.querySelector('button.btn.icon-x');
     this.content = this.querySelector('.content');
-    this.resizeHandle = this.querySelector('.kite-sidebar-resizer');
     this.input = this.querySelector('input');
     this.element = this;
   }
 
   attachedCallback() {
-    this.classList.toggle('dockable', this.Kite.isUsingDockForSidebar());
-
     this.subscriptions = new CompositeDisposable();
 
     this.subscriptions.add(atom.config.observe('kite.openAutocorrectSidebarOnSave', (v) => {
@@ -97,22 +89,6 @@ class KiteAutocorrectSidebar extends HTMLElement {
       e.target.classList.add('clicked');
       parent(e.target, '.diff').classList.add('feedback-sent');
     }));
-
-    if (!this.Kite.isUsingDockForSidebar()) {
-      this.subscriptions.add(new DisposableEvent(this.closeBtn, 'click', (e) => {
-        atom.commands.dispatch(this, 'kite:close-autocorrect-sidebar');
-      }));
-
-      this.subscriptions.add(new DisposableEvent(this.resizeHandle, 'mousedown', e => {
-        this.startResize(e);
-      }));
-
-      this.subscriptions.add(atom.config.observe('kite.sidebarWidth', (width) => {
-        this.style.width = `${width}px`;
-      }));
-    } else {
-      this.style.width = null;
-    }
 
     this.renderDiffs(this.getCurrentEditorCorrectionsHistory());
   }

--- a/lib/elements/kite-sidebar.js
+++ b/lib/elements/kite-sidebar.js
@@ -42,7 +42,6 @@ class KiteSidebar extends NavigablePanel {
       <div class="kite-column">
         <header>
           <kite-navigable-stack-breadcrumb></kite-navigable-stack-breadcrumb>
-          <button class="btn icon icon-x"></button>
         </header>
 
         <kite-navigable-stack></kite-navigable-stack>

--- a/lib/elements/kite-sidebar.js
+++ b/lib/elements/kite-sidebar.js
@@ -85,6 +85,11 @@ class KiteSidebar extends NavigablePanel {
     });
   }
 
+  setData(hover, report, noMetrics) {
+    super.setData(hover, report, noMetrics);
+    this.Kite.activateAndShowItem(this);
+  }
+
   resize(e, {startX, startWidth, position}) {
     const {pageX} = e;
     const dif = pageX - startX;

--- a/lib/elements/kite-sidebar.js
+++ b/lib/elements/kite-sidebar.js
@@ -39,7 +39,6 @@ class KiteSidebar extends NavigablePanel {
 
   createdCallback() {
     this.innerHTML = `
-      <div class="kite-sidebar-resizer"></div>
       <div class="kite-column">
         <header>
           <kite-navigable-stack-breadcrumb></kite-navigable-stack-breadcrumb>
@@ -50,10 +49,8 @@ class KiteSidebar extends NavigablePanel {
       </div>
     `;
 
-    this.closeBtn = this.querySelector('button.btn.icon-x');
     this.breadcrumb = this.querySelector('kite-navigable-stack-breadcrumb');
     this.content = this.querySelector('kite-navigable-stack');
-    this.resizeHandle = this.querySelector('.kite-sidebar-resizer');
     this.element = this;
 
     this.emptyData();
@@ -61,26 +58,6 @@ class KiteSidebar extends NavigablePanel {
 
   attachedCallback() {
     this.subscribe();
-
-    if (this.Kite) {
-      this.classList.toggle('dockable', this.Kite.isUsingDockForSidebar());
-
-      if (!this.Kite.isUsingDockForSidebar()) {
-        this.subscriptions.add(new DisposableEvent(this.closeBtn, 'click', (e) => {
-          atom.commands.dispatch(this, 'kite:close-sidebar');
-        }));
-
-        this.subscriptions.add(new DisposableEvent(this.resizeHandle, 'mousedown', e => {
-          this.startResize(e);
-        }));
-
-        this.subscriptions.add(atom.config.observe('kite.sidebarWidth', (width) => {
-          this.style.width = `${width}px`;
-        }));
-      } else {
-        this.style.width = null;
-      }
-    }
   }
 
   detachedCallback() {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -571,12 +571,9 @@ module.exports = {
       pane.removeItem(item);
     } else if (!this.isSidebarVisible() && visible) {
       const position = atom.config.get('kite.sidebarPosition');
-      const width = atom.config.get('kite.sidebarWidth');
 
       this.sidebar = new KiteSidebar();
       this.sidebar.Kite = this;
-
-      this.sidebar.style.width = `${width}px`;
 
       atom.workspace.open(this.sidebar, {
         searchAllPanes: true,
@@ -606,12 +603,8 @@ module.exports = {
       }
     } else if (!this.isAutocorrectSidebarVisible() && visible) {
       const position = atom.config.get('kite.sidebarPosition');
-      const width = atom.config.get('kite.sidebarWidth');
-
       this.autocorrectSidebar = new KiteAutocorrectSidebar();
       this.autocorrectSidebar.Kite = this;
-
-      this.autocorrectSidebar.style.width = `${width}px`;
 
       atom.workspace.open(this.autocorrectSidebar, {
         searchAllPanes: true,

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -561,6 +561,18 @@ module.exports = {
     return true;
   },
 
+  activateAndShowItem(item) {
+    if (item) {
+      const dock = atom.workspace.paneContainerForURI(item.getURI());
+      const pane = atom.workspace.paneForURI(item.getURI());
+
+      if (pane && dock) {
+        dock.show();
+        pane.setActiveItem(item);
+      }
+    }
+  },
+
   toggleSidebar(visible) {
     if (visible == null) { visible = !this.isSidebarVisible(); }
     if (!KiteSidebar) { KiteSidebar = require('./elements/kite-sidebar'); }

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -301,30 +301,21 @@ module.exports = {
 
     this.subscriptions.add(atom.config.observe('kite.sidebarPosition', (position) => {
       if (this.isSidebarVisible()) {
-        if (this.isUsingDockForSidebar()) {
-          const pane = atom.workspace.paneForURI(this.sidebar.getURI());
-          const wasActiveItem = pane.getActiveItem() === this.sidebar;
-          const dock = position === 'left'
-            ? atom.workspace.getLeftDock()
-            : atom.workspace.getRightDock();
+        const pane = atom.workspace.paneForURI(this.sidebar.getURI());
+        const wasActiveItem = pane.getActiveItem() === this.sidebar;
+        const dock = position === 'left'
+        ? atom.workspace.getLeftDock()
+        : atom.workspace.getRightDock();
 
-          pane.removeItem(this.sidebar);
+        pane.removeItem(this.sidebar);
 
-          if (!dock.isVisible()) {
-            dock.show();
-          }
-          dock.getActivePane().addItem(this.sidebar);
+        if (!dock.isVisible()) {
+          dock.show();
+        }
+        dock.getActivePane().addItem(this.sidebar);
 
-          if (dock.getActivePaneItem() !== this.sidebar && wasActiveItem) {
-            dock.getActivePane().activateItem(this.sidebar);
-          }
-
-        } else {
-          this.sidebarPanel.destroy();
-
-          this.sidebarPanel = position === 'left'
-            ? atom.workspace.addLeftPanel({item: this.sidebar})
-            : atom.workspace.addRightPanel({item: this.sidebar});
+        if (dock.getActivePaneItem() !== this.sidebar && wasActiveItem) {
+          dock.getActivePane().activateItem(this.sidebar);
         }
       }
     }));
@@ -575,20 +566,9 @@ module.exports = {
     if (!KiteSidebar) { KiteSidebar = require('./elements/kite-sidebar'); }
 
     if (this.isSidebarVisible() && !visible) {
-      if (this.isUsingDockForSidebar()) {
-        const pane = atom.workspace.paneForURI(this.sidebar.getURI());
-        const item = pane.itemForURI(this.sidebar.getURI());
-        pane.removeItem(item);
-      } else {
-        this.sidebarPanel.destroy();
-        delete this.sidebar;
-        delete this.sidebarPanel;
-        const editor = atom.workspace.getActiveTextEditor();
-        if (editor) {
-          const view = atom.views.getView(editor);
-          view.focus();
-        }
-      }
+      const pane = atom.workspace.paneForURI(this.sidebar.getURI());
+      const item = pane.itemForURI(this.sidebar.getURI());
+      pane.removeItem(item);
     } else if (!this.isSidebarVisible() && visible) {
       const position = atom.config.get('kite.sidebarPosition');
       const width = atom.config.get('kite.sidebarWidth');
@@ -598,25 +578,19 @@ module.exports = {
 
       this.sidebar.style.width = `${width}px`;
 
-      if (this.isUsingDockForSidebar()) {
-        atom.workspace.open(this.sidebar, {
-          searchAllPanes: true,
-          activatePane: false,
-          activateItem: false,
-          location: position,
-        }).then(() => {
-          const dock = atom.workspace.paneContainerForURI(this.sidebar.getURI());
-          const pane = atom.workspace.paneForURI(this.sidebar.getURI());
-          if (dock.getActivePaneItem() !== this.sidebar) {
-            pane.activateItem(this.sidebar);
-          }
-          dock.show();
-        });
-      } else {
-        this.sidebarPanel = position === 'left'
-          ? atom.workspace.addLeftPanel({item: this.sidebar})
-          : atom.workspace.addRightPanel({item: this.sidebar});
-      }
+      atom.workspace.open(this.sidebar, {
+        searchAllPanes: true,
+        activatePane: false,
+        activateItem: false,
+        location: position,
+      }).then(() => {
+        const dock = atom.workspace.paneContainerForURI(this.sidebar.getURI());
+        const pane = atom.workspace.paneForURI(this.sidebar.getURI());
+        if (dock.getActivePaneItem() !== this.sidebar) {
+          pane.activateItem(this.sidebar);
+        }
+        dock.show();
+      });
     }
   },
 
@@ -625,19 +599,10 @@ module.exports = {
     if (!KiteAutocorrectSidebar) { KiteAutocorrectSidebar = require('./elements/kite-autocorrect-sidebar'); }
 
     if (this.isAutocorrectSidebarVisible() && !visible) {
-      if (this.isUsingDockForSidebar()) {
-        const pane = atom.workspace.paneForURI(this.autocorrectSidebar.getURI());
+      const pane = atom.workspace.paneForURI(this.autocorrectSidebar.getURI());
+      if (pane) {
         const item = pane.itemForURI(this.autocorrectSidebar.getURI());
         pane.removeItem(item);
-      } else {
-        this.autocorrectSidebarPanel.destroy();
-        delete this.autocorrectSidebar;
-        delete this.autocorrectSidebarPanel;
-        const editor = atom.workspace.getActiveTextEditor();
-        if (editor) {
-          const view = atom.views.getView(editor);
-          view.focus();
-        }
       }
     } else if (!this.isAutocorrectSidebarVisible() && visible) {
       const position = atom.config.get('kite.sidebarPosition');
@@ -648,31 +613,20 @@ module.exports = {
 
       this.autocorrectSidebar.style.width = `${width}px`;
 
-      if (this.isUsingDockForSidebar()) {
-        atom.workspace.open(this.autocorrectSidebar, {
-          searchAllPanes: true,
-          activatePane: false,
-          activateItem: false,
-          location: position,
-        }).then(() => {
-          const dock = atom.workspace.paneContainerForURI(this.autocorrectSidebar.getURI());
-          const pane = atom.workspace.paneForURI(this.autocorrectSidebar.getURI());
-          if (dock.getActivePaneItem() !== this.autocorrectSidebar) {
-            pane.activateItem(this.autocorrectSidebar);
-          }
-          dock.show();
-        });
-      } else {
-        this.autocorrectSidebarPanel = position === 'left'
-          ? atom.workspace.addLeftPanel({item: this.autocorrectSidebar})
-          : atom.workspace.addRightPanel({item: this.autocorrectSidebar});
-      }
+      atom.workspace.open(this.autocorrectSidebar, {
+        searchAllPanes: true,
+        activatePane: false,
+        activateItem: false,
+        location: position,
+      }).then(() => {
+        const dock = atom.workspace.paneContainerForURI(this.autocorrectSidebar.getURI());
+        const pane = atom.workspace.paneForURI(this.autocorrectSidebar.getURI());
+        if (dock.getActivePaneItem() !== this.autocorrectSidebar) {
+          pane.activateItem(this.autocorrectSidebar);
+        }
+        dock.show();
+      });
     }
-  },
-
-  isUsingDockForSidebar() {
-    return atom.workspace.getRightDock &&
-           atom.config.get('kite.useDockForSidebar');
   },
 
   openSidebarAtRange(editor, range) {

--- a/package.json
+++ b/package.json
@@ -56,10 +56,6 @@
       "default": 400,
       "description": "Defines the width of the sidebar. When the sidebar is displayed using the new dock API this value will serve as the preferred width."
     },
-    "useDockForSidebar": {
-      "type": "boolean",
-      "default": false
-    },
     "openSidebarOnStartup": {
       "type": "boolean",
       "default": false,

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -14,13 +14,20 @@ describe('autocorrect', () => {
   fakeKiteInstallPaths();
 
   beforeEach(() => {
-    jasmineContent = document.querySelector('#jasmine-content');
+    jasmineContent = document.body.querySelector('#jasmine-content');
     workspaceElement = atom.views.getView(atom.workspace);
 
-    // We want to test that our sidebar closes properly when not using the dock API.
-    atom.config.set('kite.useDockForSidebar', false);
     atom.config.set('kite.openAutocorrectSidebarOnSave', false);
 
+    // Use these styles if you need to display the workspace when running the tests
+    // jasmineContent.innerHTML = `
+    // <style>
+    //   atom-workspace {
+    //     z-index: 10000000;
+    //     height: 500px;
+    //     opacity: 0.5;
+    //   }
+    // </style>`;
     jasmineContent.appendChild(workspaceElement);
 
     waitsForPromise(() => atom.packages.activatePackage('status-bar'));
@@ -181,7 +188,8 @@ describe('autocorrect', () => {
               beforeEach(() => {
                 status = kitePkg.getAutocorrectStatusItem();
                 click(status);
-                sidebar = workspaceElement.querySelector('kite-autocorrect-sidebar');
+                waitsFor('autocorrect sidebar', () =>
+                  sidebar = workspaceElement.querySelector('kite-autocorrect-sidebar'));
               });
 
               it('opens the autocorrect sidebar panel', () => {
@@ -206,18 +214,6 @@ describe('autocorrect', () => {
 
                 expect(thumbUp).not.toBeNull();
                 expect(thumbDown).not.toBeNull();
-              });
-
-              describe('then clicking on the sidebar close button', () => {
-                beforeEach(() => {
-                  const button = sidebar.querySelector('button.icon-x');
-
-                  click(button);
-                });
-
-                it('removes the sidebar panel', () => {
-                  expect(workspaceElement.querySelector('kite-autocorrect-sidebar')).toBeNull();
-                });
               });
 
               describe('clicking on the feedback button', () => {

--- a/styles/kite-sidebar.less
+++ b/styles/kite-sidebar.less
@@ -5,18 +5,12 @@ atom-panel.left kite-sidebar {
   .kite-column {
     padding-right: @half-padding;
   }
-  .kite-sidebar-resizer {
-    order: 2;
-  }
 }
 
 atom-panel.right kite-autocorrect-sidebar,
 atom-panel.right kite-sidebar {
   .kite-column {
     padding-left: @half-padding;
-  }
-  .kite-sidebar-resizer {
-    order: 0;
   }
 }
 
@@ -26,19 +20,6 @@ kite-sidebar {
   font-size: 1em;
   font-family: @font-family;
   flex-direction: row;
-
-  &.dockable {
-    .kite-sidebar-resizer,
-    header > .btn.icon-x {
-      display: none;
-    }
-  }
-
-  .kite-sidebar-resizer {
-    width: @half-padding;
-    cursor: ew-resize;
-    flex: 0 0 auto;
-  }
 
   h4 .sticky.fixed {
     background: @app-background-color;


### PR DESCRIPTION
This PR basically remove the setting and use the dock API version wherever we were switching behavior based on that setting. Also, the sidebars no longer have a close button nor a resizer as we're letting the dock handles that for us.