### PR TITLE
Better autocorrect insert/delete colors.

### DIFF
--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -68,21 +68,21 @@ kite-autocorrect-sidebar {
       width: 80px;
       opacity: 0.5;
       padding: @component-padding;
-      color: rgba(0,0,0,0.7);
+      color: @text-color;
     }
     .line {
       padding: @component-padding;
       padding-left: @triple-padding;
       white-space: pre;
       position: relative;
-      color: rgba(0,0,0,0.8);
+      color: @text-color;
     }
   }
   del {
-    background: fadeout(@red-color, 80%);
+    background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 15%), 20%);
 
     .line-number {
-      background: fadeout(@red-color, 60%);
+      background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 25%), 20%);
       text-align: left;
     }
     .line {
@@ -94,10 +94,10 @@ kite-autocorrect-sidebar {
     }
   }
   ins {
-    background: fadeout(@green-color, 80%);
+    background-color: saturate(mix(@syntax-color-added, @pane-item-background-color, 15%), 20%);
 
     .line-number {
-      background: fadeout(@green-color, 60%);
+      background-color: saturate(mix(@syntax-color-added, @pane-item-background-color, 25%), 20%);
       text-align: right;
     }
     .line {


### PR DESCRIPTION
@abe33 + @dbratz1177 

This should do a better job picking the right text colors for showing code in autocorrect. It should support dark themes much better.

Next step would be to grab the font/font size/line spacing from the editor and propagate it here. @dbratz1177 and I talked about one way to do this, but it involves JavaScript.

We can also easily the theme remove/insert colours to always be red and green if we so desire. (GitHub plugin does that.)

Some examples:

### UI Theme: One Dark · Syntax Theme: Tyrann Alex
Before:
<img width="489" alt="screen shot 2018-03-14 at 14 23 35" src="https://user-images.githubusercontent.com/2061609/37431767-66049c72-2793-11e8-90e3-2de3c064c18d.png">

After:
<img width="488" alt="screen shot 2018-03-14 at 14 23 23" src="https://user-images.githubusercontent.com/2061609/37431762-62b3185a-2793-11e8-8047-5c630968fe82.png">

### UI Theme: Atom Dark · Syntax Theme: Atom Dark 
Before:
<img width="481" alt="screen shot 2018-03-14 at 14 17 03" src="https://user-images.githubusercontent.com/2061609/37431615-fa10d8c8-2792-11e8-9e5b-411f3e3f48af.png">
After:
<img width="486" alt="screen shot 2018-03-14 at 14 15 10" src="https://user-images.githubusercontent.com/2061609/37431621-fcb83ec2-2792-11e8-9009-4584b66c2c67.png">

### UI Theme: Atom Light · Syntax Theme: Atom Light
Before:
<img width="486" alt="screen shot 2018-03-14 at 14 17 10" src="https://user-images.githubusercontent.com/2061609/37431629-024d07aa-2793-11e8-89b7-c57423bd872c.png">
After:
<img width="483" alt="screen shot 2018-03-14 at 14 15 32" src="https://user-images.githubusercontent.com/2061609/37431636-048a6b52-2793-11e8-9ed0-0d6b3a8df353.png">

### UI Theme: Atom Light · Syntax Theme: Jackhammer
Before:
<img width="485" alt="screen shot 2018-03-14 at 14 17 17" src="https://user-images.githubusercontent.com/2061609/37431651-0ba30ce6-2793-11e8-9b2b-b82be007b0e1.png">
After:
<img width="485" alt="screen shot 2018-03-14 at 14 15 54" src="https://user-images.githubusercontent.com/2061609/37431655-0ebbe312-2793-11e8-8698-415a4d87cea2.png">

### UI Theme: One Dark · Syntax Theme: Jackhammer
Before:
<img width="484" alt="screen shot 2018-03-14 at 14 17 24" src="https://user-images.githubusercontent.com/2061609/37431660-15806916-2793-11e8-89ea-6249c9f54564.png">
After:
<img width="495" alt="screen shot 2018-03-14 at 14 16 07" src="https://user-images.githubusercontent.com/2061609/37431666-17e5d0a6-2793-11e8-8a9b-bb8393158306.png">

### UI Theme: One Light · Syntax Theme: Textmate Solarized Dark
Before:
<img width="488" alt="screen shot 2018-03-14 at 14 17 37" src="https://user-images.githubusercontent.com/2061609/37431676-203aff06-2793-11e8-821b-6f909ebe00aa.png">
After:
<img width="490" alt="screen shot 2018-03-14 at 14 16 22" src="https://user-images.githubusercontent.com/2061609/37431679-238d330e-2793-11e8-94ba-85062d690f35.png">
