### PR TITLE
eliminates .js files from consideration for suggestions

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -7,12 +7,13 @@ const {delayPromise} = require('./utils');
 let Kite;
 
 const KiteProvider = {
-  selector: '.source.python, .source.js',
+  /* selector: '.source.python, .source.js', */
+  selector: '.source.python',
   disableForSelector: [
     '.source.python .comment',
     '.source.python .string',
-    '.source.js .comment',
-    '.source.js .string',
+    /* '.source.js .comment',
+    '.source.js .string', */
   ].join(', '),
   inclusionPriority: 5,
   suggestionPriority: 5,


### PR DESCRIPTION
quick fix to issue with js files triggering calls to `clientapi/signatures` and `clientapi/completions`
Should probably, long-term, use similar `isSupported` logic (ala #333) to wrap the internals of `getSuggestions` call.