### PR TITLE
Catch virtual cursor errors in the promise

### DIFF
--- a/lib/overlay-manager.js
+++ b/lib/overlay-manager.js
@@ -96,11 +96,12 @@ module.exports = {
 
   showHoverAtPosition(editor, position) {
     const cursor = new VirtualCursor(editor, position);
-    const range = cursor.getCurrentWordBufferRange({
-      includeNonWordCharacters: false,
-    });
 
     return this.enqueue(() => {
+      const range = cursor.getCurrentWordBufferRange({
+        includeNonWordCharacters: false,
+      });
+
       if ((this.lastHoverRange && this.lastHoverRange.isEqual(range)) ||
           (this.lastExpandRange && this.lastExpandRange.isEqual(range))) {
         return null;


### PR DESCRIPTION
It prevents atom notifications to kick in.