### PR TITLE
Makes autocorrect pane use user’s code fonts.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -37,23 +37,8 @@ class KiteAutocorrectSidebar extends HTMLElement {
     return atom.config.get('kite.sidebarWidth');
   }
 
-  // Grabs code typography styles from Atom configuration and turns
-  // them into a CSS block
-  getTypographyStylesFromConfig() {
-    return `
-      <style>
-        code {
-          font-family: ${atom.config.get('editor.fontFamily')};
-          font-size: ${atom.config.get('editor.fontSize')}px;
-          line-height: ${atom.config.get('editor.lineHeight')};
-          tab-size: ${atom.config.get('editor.tabLength')};
-        }
-      </style>`
-  }
-
   createdCallback() {
     this.innerHTML = `
-      ${this.getTypographyStylesFromConfig()}
       <div class="kite-sidebar-resizer"></div>
       <div class="kite-column">
         <header>

--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -37,8 +37,23 @@ class KiteAutocorrectSidebar extends HTMLElement {
     return atom.config.get('kite.sidebarWidth');
   }
 
+  // Grabs code typography styles from Atom configuration and turns
+  // them into a CSS block
+  getTypographyStylesFromConfig() {
+    return `
+      <style>
+        code {
+          font-family: ${atom.config.get('editor.fontFamily')};
+          font-size: ${atom.config.get('editor.fontSize')}px;
+          line-height: ${atom.config.get('editor.lineHeight')};
+          tab-size: ${atom.config.get('editor.tabLength')};
+        }
+      </style>`
+  }
+
   createdCallback() {
     this.innerHTML = `
+      ${this.getTypographyStylesFromConfig()}
       <div class="kite-sidebar-resizer"></div>
       <div class="kite-column">
         <header>

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -140,6 +140,11 @@ module.exports = {
       // this.app.saveUserID();
     }));
 
+    const workspaceElement = atom.views.getView(atom.workspace);
+    if (!workspaceElement.updateGlobalTextEditorStyleSheet) {
+      this.createGlobalTextEditorStyleSheet();
+    }
+
     const Kite = this;
     const tokenMethod = (action) => () => {
       const editor = atom.workspace.getActiveTextEditor();
@@ -618,6 +623,21 @@ module.exports = {
           : atom.workspace.addRightPanel({item: this.sidebar});
       }
     }
+  },
+
+  createGlobalTextEditorStyleSheet() {
+    const listener = () => {
+      const styleSheetSource = `atom-workspace {
+        --editor-font-size: ${atom.config.get('editor.fontSize')}px;
+        --editor-font-family: ${atom.config.get('editor.fontFamily')};
+        --editor-line-height: ${atom.config.get('editor.lineHeight')};
+      }`;
+      atom.styles.addStyleSheet(styleSheetSource, {sourcePath: 'kite-global-text-editor-styles', priority: -1});
+    };
+
+    atom.config.observe('atom.fontSize', listener);
+    atom.config.observe('atom.fontFamily', listener);
+    atom.config.observe('atom.lineHeight', listener);
   },
 
   toggleAutocorrectSidebar(visible) {

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -67,11 +67,11 @@ kite-autocorrect-sidebar {
     .line-number {
       width: 80px;
       opacity: 0.5;
-      padding: @component-padding;
+      padding: 2px @component-padding;
       color: @text-color;
     }
     .line {
-      padding: @component-padding;
+      padding: 2px;
       padding-left: @triple-padding;
       white-space: pre;
       position: relative;
@@ -88,6 +88,7 @@ kite-autocorrect-sidebar {
     .line {
       &::before {
         content: '-';
+        opacity: 0.5;
         position: absolute;
         left: @component-padding;
       }
@@ -103,6 +104,7 @@ kite-autocorrect-sidebar {
     .line {
       &::before {
         content: '+';
+        opacity: 0.5;
         position: absolute;
         left: @component-padding;
       }

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -67,11 +67,11 @@ kite-autocorrect-sidebar {
     .line-number {
       width: 80px;
       opacity: 0.5;
-      padding: 2px @component-padding;
+      padding: 4px @component-padding;
       color: @text-color;
     }
     .line {
-      padding: 2px;
+      padding: 4px;
       padding-left: @triple-padding;
       white-space: pre;
       position: relative;

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -5,6 +5,11 @@ kite-autocorrect-sidebar {
     background: transparent !important;
     padding: 0 !important;
   }
+  code {
+    font-family: var(--editor-font-family);
+    font-size: var(--editor-font-size);
+    line-height: var(--editor-line-height);
+  }
   .content {
     flex: 1 1 auto;
   }


### PR DESCRIPTION
@abe33 /cc @dbratz1177 

This is a pretty naïve way of doing this. I can imagine in the future this needs to be extended to cover all the panels (and also react in real time when user makes changes to these fonts).

However, I’m also interested in getting this in for autocorrect first, to see if we get any feedback on this.

Let me know if this needs to be structured better or placed elsewhere even for MVP.

Before, generic font:
<img width="490" alt="screen shot 2018-03-15 at 10 18 26" src="https://user-images.githubusercontent.com/2061609/37482207-05b3a5e4-2841-11e8-950a-cf20cfd0e567.png">

After, exactly the font I use for editing:
<img width="489" alt="screen shot 2018-03-15 at 11 09 55" src="https://user-images.githubusercontent.com/2061609/37482456-6a7365d2-2841-11e8-8a2f-0535fcbcd959.png">
<img width="701" alt="image" src="https://user-images.githubusercontent.com/2061609/37482463-6f7e21e8-2841-11e8-9e5b-2341390f50b4.png">

