### PR TITLE
Make long autocorrect lines better.

### DIFF
--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -75,6 +75,7 @@ kite-autocorrect-sidebar {
       padding-left: @triple-padding;
       position: relative;
       color: @text-color;
+      white-space: pre-wrap;
 
       // Indent every line except the first one by 4 spaces
       margin-left: 4ch;

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -73,9 +73,19 @@ kite-autocorrect-sidebar {
     .line {
       padding: @component-padding;
       padding-left: @triple-padding;
-      white-space: pre;
       position: relative;
       color: @text-color;
+
+      // Indent every line except the first one by 4 spaces
+      margin-left: 4ch;
+      text-indent: -4ch;
+
+      &::before {
+        opacity: 0.5;
+        position: absolute;
+        left: 0;
+        padding-left: @component-padding;
+      }
     }
   }
   del {
@@ -88,8 +98,6 @@ kite-autocorrect-sidebar {
     .line {
       &::before {
         content: '-';
-        position: absolute;
-        left: @component-padding;
       }
     }
   }
@@ -103,8 +111,6 @@ kite-autocorrect-sidebar {
     .line {
       &::before {
         content: '+';
-        position: absolute;
-        left: @component-padding;
       }
     }
   }


### PR DESCRIPTION
@abe33 /cc @dbratz1177 

Instead of stretching the before/after lines into infinity, wrap the line so that the user can actually see what change we’ve done if that change is farther to the right.

Currently, the 2nd/3rd/xth lines will be indented by 4 characters. Once this PR is merged –  https://github.com/kiteco/atom-plugin/pull/346 – we can make it better by using “2 * current indentation” instead of 4 instead.

Before:
<img width="557" alt="screen shot 2018-03-15 at 11 30 01" src="https://user-images.githubusercontent.com/2061609/37485009-73dbba1a-2847-11e8-9001-21cb2a12b861.png">

After:
<img width="561" alt="screen shot 2018-03-15 at 11 45 20" src="https://user-images.githubusercontent.com/2061609/37485017-79be3020-2847-11e8-9945-e7d38b5dc5af.png">
