### PR TITLE
Nicer headers.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -134,8 +134,23 @@ class KiteAutocorrectSidebar extends HTMLElement {
 
   renderDiffs([history, filename] = []) {
     if (history) {
-      const diffsHTML = history.map(fix =>
-        `<div class="diff">
+      const diffsHTML = history.map((fix, index) => {
+        let html = ''
+        switch (index) {
+          case 0:
+            html += `<div class="diff">
+                <div class="file">Corrections in ${filename}</div>`
+            break
+          case 1:
+            html += `<div class="diff history">
+                <div class="file">Earlier corrections</div>`
+            break
+          default:
+            html += `<div class="diff history">`
+            break
+        }
+
+        html += `
           <div class="timestamp">
             Fixed ${fix.diffs.length} ${fix.diffs.length === 1 ? 'error' : 'errors'} on ${fix.timestamp}
           </div>
@@ -158,12 +173,11 @@ class KiteAutocorrectSidebar extends HTMLElement {
             <a class="thumb-down" title="Send feedback to Kite if you don’t like this change">👎</a>
           </div>
         </div>`
-      ).join('');
 
-      this.content.innerHTML = `
-        <div class="file">Corrections in ${filename}</div>
-        <div class="diffs">${diffsHTML}</div>
-      `;
+        return html
+      }).join('');
+
+      this.content.innerHTML = `<div class="diffs">${diffsHTML}</div>`;
     } else {
       this.content.innerHTML = '';
     }

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -9,7 +9,10 @@ kite-autocorrect-sidebar {
     flex: 1 1 auto;
   }
   .file {
-    font-size: 1.4em;
+    font-size: 1em;
+    margin-bottom: .5em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
     color: @text-color-highlight;
   }
   .diff {
@@ -17,14 +20,19 @@ kite-autocorrect-sidebar {
     margin-bottom: @double-padding;
 
     &:not(:first-child) {
-      opacity: 0.7;
+      .timestamp,
+      .diff-content {
+        opacity: 0.7;
+      }
 
       .feedback-actions {
         display: none;
         pointer-events: none;
       }
     }
-
+    &:first-child {
+      padding-bottom: 3em;
+    }
     &.feedback-sent {
       .feedback-actions {
         pointer-events: none;


### PR DESCRIPTION
@abe33 

Nicer style for headers, adds a header for the “history” section.

This header style should eventually be unified with headers in the regular panel.

New style:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/2061609/37486350-7723c1c8-284b-11e8-8b6e-2f2926b3a146.png">
