### PR TITLE
Better feedback.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -62,14 +62,14 @@ class KiteAutocorrectSidebar extends HTMLElement {
   }
 
   // Show hint or confirmation when the user hovers or clicks thumbs up/down
-  showFeedbackFeedback(e, confirmation, message) {
-    let el = parent(e.target, '.feedback-actions').querySelector('.feedback-feedback')
+  showFeedbackFeedback(target, message, {confirmation}={}) {
+    let el = parent(target, '.feedback-actions').querySelector('.feedback-feedback')
     el.classList.add(confirmation ? 'confirmation' : 'hint')
     el.innerHTML = message;
   }
 
-  hideFeedbackFeedback(e) {
-    let el = parent(e.target, '.feedback-actions').querySelector('.feedback-feedback')
+  hideFeedbackFeedback(target) {
+    let el = parent(target, '.feedback-actions').querySelector('.feedback-feedback')
     el.classList.remove('hint')
   }
 
@@ -103,7 +103,7 @@ class KiteAutocorrectSidebar extends HTMLElement {
       e.target.classList.add('clicked');
       parent(e.target, '.diff').classList.add('feedback-sent');
 
-      this.showFeedbackFeedback(e, true, 'Thanks for your feedback!')
+      this.showFeedbackFeedback(e.target, 'Thanks for your feedback!', {confirmation: true})
     }));
 
     this.subscriptions.add(addDelegatedEventListener(this, 'click', '.thumb-down', (e) => {
@@ -111,23 +111,21 @@ class KiteAutocorrectSidebar extends HTMLElement {
       e.target.classList.add('clicked');
       parent(e.target, '.diff').classList.add('feedback-sent');
 
-      this.showFeedbackFeedback(e, true, 'Thank you for your feedback!')
+      this.showFeedbackFeedback(e.target, 'Thank you for your feedback!', {confirmation: true})
     }));
 
     this.subscriptions.add(addDelegatedEventListener(this, 'mouseover', '.thumb-up', (e) => {
-      this.showFeedbackFeedback(e, false, 'Send feedback to Kite if you like this change')
+      this.showFeedbackFeedback(e.target, 'Send feedback to Kite if you like this change',
+          {confirmation: false})
     }));
 
     this.subscriptions.add(addDelegatedEventListener(this, 'mouseover', '.thumb-down', (e) => {
-      this.showFeedbackFeedback(e, false, 'Send feedback to Kite if you don’t like this change')
+      this.showFeedbackFeedback(e.target, 'Send feedback to Kite if you don’t like this change',
+          {confirmation: false})
     }));
 
-    this.subscriptions.add(addDelegatedEventListener(this, 'mouseout', '.thumb-up', (e) => {
-      this.hideFeedbackFeedback(e)
-    }));
-
-    this.subscriptions.add(addDelegatedEventListener(this, 'mouseout', '.thumb-down', (e) => {
-      this.hideFeedbackFeedback(e)
+    this.subscriptions.add(addDelegatedEventListener(this, 'mouseout', '.thumb-up, .thumb-down', (e) => {
+      this.hideFeedbackFeedback(e.target)
     }));
 
     if (!this.Kite.isUsingDockForSidebar()) {

--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -61,6 +61,18 @@ class KiteAutocorrectSidebar extends HTMLElement {
     this.element = this;
   }
 
+  // Show hint or confirmation when the user hovers or clicks thumbs up/down
+  showFeedbackFeedback(e, confirmation, message) {
+    let el = parent(e.target, '.feedback-actions').querySelector('.feedback-feedback')
+    el.classList.add(confirmation ? 'confirmation' : 'hint')
+    el.innerHTML = message;
+  }
+
+  hideFeedbackFeedback(e) {
+    let el = parent(e.target, '.feedback-actions').querySelector('.feedback-feedback')
+    el.classList.remove('hint')
+  }
+
   attachedCallback() {
     this.classList.toggle('dockable', this.Kite.isUsingDockForSidebar());
 
@@ -90,12 +102,32 @@ class KiteAutocorrectSidebar extends HTMLElement {
       DataLoader.postAutocorrectFeedbackData(this.getCurrentEditorLastCorrections(), +1);
       e.target.classList.add('clicked');
       parent(e.target, '.diff').classList.add('feedback-sent');
+
+      this.showFeedbackFeedback(e, true, 'Thanks for your feedback!')
     }));
 
     this.subscriptions.add(addDelegatedEventListener(this, 'click', '.thumb-down', (e) => {
       DataLoader.postAutocorrectFeedbackData(this.getCurrentEditorLastCorrections(), -1);
       e.target.classList.add('clicked');
       parent(e.target, '.diff').classList.add('feedback-sent');
+
+      this.showFeedbackFeedback(e, true, 'Thank you for your feedback!')
+    }));
+
+    this.subscriptions.add(addDelegatedEventListener(this, 'mouseover', '.thumb-up', (e) => {
+      this.showFeedbackFeedback(e, false, 'Send feedback to Kite if you like this change')
+    }));
+
+    this.subscriptions.add(addDelegatedEventListener(this, 'mouseover', '.thumb-down', (e) => {
+      this.showFeedbackFeedback(e, false, 'Send feedback to Kite if you don’t like this change')
+    }));
+
+    this.subscriptions.add(addDelegatedEventListener(this, 'mouseout', '.thumb-up', (e) => {
+      this.hideFeedbackFeedback(e)
+    }));
+
+    this.subscriptions.add(addDelegatedEventListener(this, 'mouseout', '.thumb-down', (e) => {
+      this.hideFeedbackFeedback(e)
     }));
 
     if (!this.Kite.isUsingDockForSidebar()) {
@@ -154,8 +186,9 @@ class KiteAutocorrectSidebar extends HTMLElement {
             ].join('')
           ).join('')}
           <div class="feedback-actions">
-            <a class="thumb-up" title="Send feedback to Kite if you like this change">👍</a>
-            <a class="thumb-down" title="Send feedback to Kite if you don’t like this change">👎</a>
+            <a class="thumb-up" aria-label="Send feedback to Kite if you like this change">👍</a>
+            <a class="thumb-down" aria-label="Send feedback to Kite if you don’t like this change">👎</a>
+            <span class="feedback-feedback"></span>
           </div>
         </div>`
       ).join('');

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -48,17 +48,37 @@ kite-autocorrect-sidebar {
   }
 
   .feedback-actions {
-    text-align: right;
+    display: flex;
+    text-align: left;
     margin-top: @component-padding;
 
     a {
-      margin-right: @component-padding;
+      padding-left: @component-padding / 2;
+      padding-right: @component-padding / 2;
+      filter: saturate(0);
+      opacity: .5;
     }
 
     a:hover {
       text-decoration: none;
+      filter: none;
+      opacity: 1;
     }
   }
+  .feedback-feedback {
+    min-height: 3em; // Allocate room for at least two lines
+    padding-left: .4em;
+    color: transparent;
+    transition: color 300ms;
+    &.hint {
+      color: @text-color-subtle;
+    }
+    &.confirmation {
+      color: @text-color-highlight;
+    }
+  }
+
+
   del, ins {
     display: flex;
     flex-direction: row;

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -53,8 +53,8 @@ kite-autocorrect-sidebar {
     margin-top: @component-padding;
 
     a {
-      padding-left: @component-padding / 2;
-      padding-right: @component-padding / 2;
+      padding-left: @half-padding;
+      padding-right: @half-padding;
       filter: saturate(0);
       opacity: .5;
     }


### PR DESCRIPTION
@abe33

· replace tooltips when you hover over thumbs up/down to be nicer and quicker
· add post-click feedback, too
· move thumbs up/down to the help
· style thumbs up/down to be less prominent

<img width="334" alt="screen shot 2018-03-15 at 14 23 47" src="https://user-images.githubusercontent.com/2061609/37491968-bc05ea26-285c-11e8-8e6b-d14f21d2fce4.png">
<img width="333" alt="screen shot 2018-03-15 at 14 23 40" src="https://user-images.githubusercontent.com/2061609/37491969-bd770f48-285c-11e8-937e-dea025cbf222.png">
