### PR TITLE
Add a better empty state for when autocorrect haven't made any changes yet.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -133,7 +133,7 @@ class KiteAutocorrectSidebar extends HTMLElement {
   }
 
   renderDiffs([history, filename] = []) {
-    if (history) {
+    if (history && history.length) {
       const diffsHTML = history.map(fix =>
         `<div class="diff">
           <div class="timestamp">
@@ -161,11 +161,14 @@ class KiteAutocorrectSidebar extends HTMLElement {
       ).join('');
 
       this.content.innerHTML = `
-        <div class="file">Corrections in ${filename}</div>
+        <div class="file">Most recent code fixes</div>
         <div class="diffs">${diffsHTML}</div>
       `;
     } else {
-      this.content.innerHTML = '';
+      this.content.innerHTML = `
+        <div class="file">Most recent code fixes</div>
+        <div class="diffs">No fixes made to ${filename} yet.</div>
+      `;
     }
   }
 

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -330,7 +330,7 @@ describe('autocorrect', () => {
               it('clears the sidebar content', () => {
                 const message = sidebar.querySelector('.diff .diffs');
 
-                expect(message.textContent).toEqual('No fixes made to errored.py yet.');
+                expect(message.textContent).toEqual('No fixes made to sample.py yet.');
               });
 
               it('clears the status bar content', () => {

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -328,9 +328,9 @@ describe('autocorrect', () => {
               });
 
               it('clears the sidebar content', () => {
-                const diff = sidebar.querySelector('.diff');
+                const message = sidebar.querySelector('.diff .diffs');
 
-                expect(diff).toBeNull();
+                expect(message.textContent).toEqual('No fixes made to errored.py yet.');
               });
 
               it('clears the status bar content', () => {


### PR DESCRIPTION
@abe33

Should make it less confusing as you move between the files and keep the pane open.

<img width="490" alt="screen shot 2018-03-15 at 16 43 55" src="https://user-images.githubusercontent.com/2061609/37496868-442ba0fc-2872-11e8-89b5-12db875ed113.png">
