### PR TITLE
no event, completion, or sig hit for non-whitelisted files

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -22,7 +22,7 @@ const KiteProvider = {
   getSuggestions(params) {
     if (!Kite) { Kite = require('./kite'); }
 
-    return Kite.app.isGrammarSupported(params.editor)
+    return Kite.isEditorWhitelisted(params.editor) && Kite.app.isGrammarSupported(params.editor)
       ? delayPromise(() => {
         let promise = Plan.queryPlan();
         if (this.isInsideFunctionCall(params)) {

--- a/lib/editor-events.js
+++ b/lib/editor-events.js
@@ -10,8 +10,6 @@ class EditorEvents {
   constructor(editor) {
     if (!Kite) { Kite = require('./kite'); }
     this.editor = editor;
-    //this is a quick and hacky way to get the tests to pass in editor-events-spec.js
-    //would love to find a cleaner way to do this
     this.subscriptions = new CompositeDisposable();
     this.pendingEvents = [];
 

--- a/lib/editor-events.js
+++ b/lib/editor-events.js
@@ -7,24 +7,19 @@ const {last, promisifyRequest, DisposableEvent} = require('./utils');
 let Kite;
 
 class EditorEvents {
-  constructor(editor, isTest) {
+  constructor(editor) {
     if (!Kite) { Kite = require('./kite'); }
     this.editor = editor;
     //this is a quick and hacky way to get the tests to pass in editor-events-spec.js
     //would love to find a cleaner way to do this
-    this.isTest = isTest;
     this.subscriptions = new CompositeDisposable();
     this.pendingEvents = [];
 
     this.subscriptions.add(editor.onDidChange(changes => {
-      if (isTest || Kite.isEditorWhitelisted(editor)) {
-        this.send(this.buildEvent(editor, 'edit'));
-      }
+      this.send(this.buildEvent(editor, 'edit'));
     }));
     this.subscriptions.add(editor.onDidChangeSelectionRange(() => {
-      if (isTest || Kite.isEditorWhitelisted(editor)) {
-        this.send(this.buildEvent(editor, 'selection'));
-      }
+      this.send(this.buildEvent(editor, 'selection'));
     }));
 
     const view = atom.views.getView(this.editor);
@@ -44,9 +39,7 @@ class EditorEvents {
   }
 
   focus() {
-    if (this.isTest || Kite.isEditorWhitelisted(this.editor)) {
-      this.send(this.buildEvent(this.editor, 'focus'));
-    }
+    this.send(this.buildEvent(this.editor, 'focus'));
   }
 
   dispose() {
@@ -90,6 +83,7 @@ class EditorEvents {
       method: 'POST',
     }, payload))
     .then(resp => {
+      Kite.handle403Response(this.editor, resp);
       Logger.logResponse(resp);
     });
   }

--- a/lib/editor-events.js
+++ b/lib/editor-events.js
@@ -7,19 +7,22 @@ const {last, promisifyRequest, DisposableEvent} = require('./utils');
 let Kite;
 
 class EditorEvents {
-  constructor(editor) {
+  constructor(editor, isTest) {
     if (!Kite) { Kite = require('./kite'); }
     this.editor = editor;
+    //this is a quick and hacky way to get the tests to pass in editor-events-spec.js
+    //would love to find a cleaner way to do this
+    this.isTest = isTest;
     this.subscriptions = new CompositeDisposable();
     this.pendingEvents = [];
 
     this.subscriptions.add(editor.onDidChange(changes => {
-      if (Kite.isEditorWhitelisted(editor)) {
+      if (isTest || Kite.isEditorWhitelisted(editor)) {
         this.send(this.buildEvent(editor, 'edit'));
       }
     }));
     this.subscriptions.add(editor.onDidChangeSelectionRange(() => {
-      if (Kite.isEditorWhitelisted(editor)) {
+      if (isTest || Kite.isEditorWhitelisted(editor)) {
         this.send(this.buildEvent(editor, 'selection'));
       }
     }));
@@ -41,7 +44,7 @@ class EditorEvents {
   }
 
   focus() {
-    if (Kite.isEditorWhitelisted(this.editor)) {
+    if (this.isTest || Kite.isEditorWhitelisted(this.editor)) {
       this.send(this.buildEvent(this.editor, 'focus'));
     }
   }

--- a/lib/editor-events.js
+++ b/lib/editor-events.js
@@ -4,18 +4,24 @@ const {CompositeDisposable} = require('atom');
 const {StateController, Logger} = require('kite-installer');
 const {MAX_FILE_SIZE, MAX_PAYLOAD_SIZE} = require('./constants');
 const {last, promisifyRequest, DisposableEvent} = require('./utils');
+let Kite;
 
 class EditorEvents {
   constructor(editor) {
+    if (!Kite) { Kite = require('./kite'); }
     this.editor = editor;
     this.subscriptions = new CompositeDisposable();
     this.pendingEvents = [];
 
     this.subscriptions.add(editor.onDidChange(changes => {
-      this.send(this.buildEvent(editor, 'edit'));
+      if (Kite.isEditorWhitelisted(editor)) {
+        this.send(this.buildEvent(editor, 'edit'));
+      }
     }));
     this.subscriptions.add(editor.onDidChangeSelectionRange(() => {
-      this.send(this.buildEvent(editor, 'selection'));
+      if (Kite.isEditorWhitelisted(editor)) {
+        this.send(this.buildEvent(editor, 'selection'));
+      }
     }));
 
     const view = atom.views.getView(this.editor);
@@ -35,7 +41,9 @@ class EditorEvents {
   }
 
   focus() {
-    this.send(this.buildEvent(this.editor, 'focus'));
+    if (Kite.isEditorWhitelisted(this.editor)) {
+      this.send(this.buildEvent(this.editor, 'focus'));
+    }
   }
 
   dispose() {

--- a/spec/editor-events-spec.js
+++ b/spec/editor-events-spec.js
@@ -20,7 +20,7 @@ describe('EditorEvents', () => {
       beforeEach(() => {
         waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
           editor = e;
-          events = new EditorEvents(editor, true);
+          events = new EditorEvents(editor);
         }));
       });
 

--- a/spec/editor-events-spec.js
+++ b/spec/editor-events-spec.js
@@ -20,7 +20,7 @@ describe('EditorEvents', () => {
       beforeEach(() => {
         waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
           editor = e;
-          events = new EditorEvents(editor);
+          events = new EditorEvents(editor, true);
         }));
       });
 


### PR DESCRIPTION
adds checks to eliminate `clientapi/editor/[event | signature | completion]` calls for non-whitelisted python files
cc: @tarakju 
should eliminate a number of `403`s to those endpoints

NB: I added a quick and somewhat dirty hack to get the tests to pass for this. Would love to do it in a cleaner way, but this seemed by far the simplest way to do so