### PR TITLE
fix for signature triggering

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -44,8 +44,11 @@ const KiteProvider = {
   isInsideFunctionCall({scopeDescriptor}) {
     return scopeDescriptor.scopes.some(s =>
       s.indexOf('function-call') !== -1 ||
-      s.indexOf('method-call') !== -1 ||
-      s.indexOf('arguments') !== -1
+      s.indexOf('method-call') !== -1
+    ) &&
+    scopeDescriptor.scopes.some(s => 
+      s.indexOf('punctuation.definition.arguments.end.bracket.round.python') !== -1 ||
+      /(function|method)-call\.arguments/.test(s)
     );
   },
 


### PR DESCRIPTION
Changes conditions where `signatures` are triggered
Prior, they would be triggered in e.g. `json.dumps()` on edits w/in the `dumps` and prior to the period (and would always yield a `404`)
The idea with this is to only trigger `signatures` with keystrokes between the parens, reducing `404`s

cc: @tarakju 