### PR TITLE
Swap autocorrect new model icon to blue info icon from a red exclamation point icon.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -326,7 +326,7 @@ class KiteAutocorrectSidebar extends HTMLElement {
       this.renderModelInfo(data);
 
       if (!this.isActivePaneItem()) {
-        this.tabIcon = 'issue-opened';
+        this.tabIcon = 'info';
         this.emitter.emit('did-change-icon');
 
         const sub = this.getPane().onDidChangeActiveItem((item) => {

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -137,9 +137,6 @@ class KiteEditor {
 
           metrics.featureApplied('autocorrect');
 
-          // DEBUG
-          firstRunExperience = true
-
           if ((firstRunExperience || this.mustOpenSidebar()) &&
              !Kite.isAutocorrectSidebarVisible()) {
             Kite.toggleAutocorrectSidebar(true);

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -137,6 +137,9 @@ class KiteEditor {
 
           metrics.featureApplied('autocorrect');
 
+          // DEBUG
+          firstRunExperience = true
+
           if ((firstRunExperience || this.mustOpenSidebar()) &&
              !Kite.isAutocorrectSidebarVisible()) {
             Kite.toggleAutocorrectSidebar(true);

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -436,7 +436,7 @@ module.exports = {
                 }],
               }],
             });
-            Kite.autocorrectSidebar.tabIcon = 'issue-opened';
+            Kite.autocorrectSidebar.tabIcon = 'info';
             Kite.autocorrectSidebar.emitter.emit('did-change-icon');
           });
         },

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -458,7 +458,7 @@ describe('autocorrect', () => {
 
                 describe('the sidebar panel tab', () => {
                   it('has a specific icon', () => {
-                    expect(kitePkg.autocorrectSidebar.getIconName()).toEqual('issue-opened');
+                    expect(kitePkg.autocorrectSidebar.getIconName()).toEqual('info');
                   });
 
                   it('creates a message box for the changes', () => {
@@ -503,7 +503,7 @@ describe('autocorrect', () => {
 
                 describe('the sidebar panel tab', () => {
                   it('does not have a specific icon', () => {
-                    expect(kitePkg.autocorrectSidebar.getIconName()).not.toEqual('issue-opened');
+                    expect(kitePkg.autocorrectSidebar.getIconName()).not.toEqual('info');
                   });
 
                   it('creates a message box for the changes', () => {

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -1,7 +1,7 @@
 @import 'variables';
 
-.tab[data-type="kite-autocorrect-sidebar"] .icon-issue-opened::before {
-  color: @text-color-error;
+.tab[data-type="kite-autocorrect-sidebar"] .icon-info::before {
+  color: @text-color-info;
 }
 
 kite-autocorrect-sidebar {


### PR DESCRIPTION
@abe33

<img width="147" alt="image" src="https://user-images.githubusercontent.com/2061609/37930256-154102e0-30f7-11e8-89ad-e240edc8c87c.png">
