### PR TITLE
Change AutoCorrect diff colours.

### DIFF
--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -215,15 +215,15 @@ class KiteAutocorrectSidebar extends HTMLElement {
         let html = '';
         switch (index) {
           case 0:
-            html += `<div class="diff">
+            html += `<div class="diff recent">
                 <h4>Most recent code fixes</h4>`;
             break;
           case 1:
-            html += `<div class="diff history">
+            html += `<div class="diff">
                 <h4>Earlier fixes</h4>`;
             break;
           default:
-            html += '<div class="diff history">';
+            html += '<div class="diff">';
             break;
         }
 

--- a/styles/kite-autocorrect-sidebar.less
+++ b/styles/kite-autocorrect-sidebar.less
@@ -89,11 +89,6 @@ kite-autocorrect-sidebar {
     }
 
     &:not(:first-child) {
-      .timestamp,
-      .diff-content {
-        opacity: 0.7;
-      }
-
       .feedback-actions {
         display: none;
         pointer-events: none;
@@ -102,10 +97,10 @@ kite-autocorrect-sidebar {
   }
   .diff-content {
     margin-top: @component-padding;
-    background: white;
     display: block;
     padding: 0;
     border-radius: 0;
+    background: transparent;
   }
 
   .feedback-actions {
@@ -147,11 +142,14 @@ kite-autocorrect-sidebar {
     flex-direction: row;
     text-decoration: none;
 
+    border: 1px solid fadeout(@text-color, 90%);
+
     .line-number {
       width: 80px;
       opacity: 0.5;
       padding: 4px @component-padding;
       color: @text-color;
+      border-right: 1px solid fadeout(@text-color, 90%);
     }
     strong {
       padding: 0.2em 0.1em;
@@ -177,36 +175,49 @@ kite-autocorrect-sidebar {
       }
     }
   }
-  del {
-    background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 15%), 20%);
+  ins {
+    border-top: 0;
+  }
+  del .line::before {
+    content: '+';
+  }
+  ins .line::before {
+    content: '-';
+  }
+  ins .line-number {
+    text-align: right;
+  }
+  del strong {
+    border: 1px solid fadeout(mix(@syntax-color-removed, @pane-item-background-color, 100%), 70%);
+  }
+  ins strong {
+    border: 1px solid fadeout(mix(@syntax-color-added, @pane-item-background-color, 100%), 70%);
+  }
 
+  .recent del {
+    border: 0;
+    margin: 0;
+    background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 15%), 20%);
     .line-number {
       background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 25%), 20%);
-      text-align: left;
+      border: none;
     }
     strong {
       background-color: saturate(mix(@syntax-color-removed, @pane-item-background-color, 35%), 20%);
-    }
-    .line {
-      &::before {
-        content: '-';
-      }
+      border: none;
     }
   }
-  ins {
+  .recent ins {
+    border: 0;
+    margin: 0;
     background-color: saturate(mix(@syntax-color-added, @pane-item-background-color, 15%), 20%);
-
     .line-number {
       background-color: saturate(mix(@syntax-color-added, @pane-item-background-color, 25%), 20%);
-      text-align: right;
+      border: none;
     }
     strong {
       background-color: saturate(mix(@syntax-color-added, @pane-item-background-color, 35%), 20%);
-    }
-    .line {
-      &::before {
-        content: '+';
-      }
+      border: none;
     }
   }
 


### PR DESCRIPTION
@dbratz1177 

[NOT LAUNCH-BLOCKING]

…so that only the current one is prominent.

Examples with different themes:

<img width="391" alt="screen shot 2018-03-27 at 14 42 10" src="https://user-images.githubusercontent.com/2061609/37996665-4d6f79e0-31cd-11e8-9fea-3304fbc3c2d9.png">
<img width="394" alt="screen shot 2018-03-27 at 14 42 26" src="https://user-images.githubusercontent.com/2061609/37996666-4d88cc38-31cd-11e8-92d2-66dc09943958.png">
<img width="394" alt="screen shot 2018-03-27 at 14 42 36" src="https://user-images.githubusercontent.com/2061609/37996667-4da51bb8-31cd-11e8-9400-2e797f298fcb.png">
<img width="391" alt="screen shot 2018-03-27 at 14 41 58" src="https://user-images.githubusercontent.com/2061609/37996674-51fad400-31cd-11e8-89c9-d854d0d32df7.png">
