### PR TITLE
Fixes for autocorrect new model notification.

### DIFF
--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -171,13 +171,14 @@ class KiteEditor {
   notifyCodeCleanUpVersionChange(version) {
     DataLoader.getAutocorrectModelInfo(version).then(data => {
       const [example] = data.examples;
-      atom.notifications.addInfo(`#### Kite code clean-up was just updated\n${example.synopsis}`, {
+      let notification = atom.notifications.addInfo(`#### Kite Error Rescue has just been updated\n${example.synopsis}`, {
         dismissable: true,
         detail: `${example.old.map(d => d.text).join('\n')}\n${example.new.map(d => d.text).join('\n')}`,
         buttons: [{
           text: 'Learn more',
           onDidClick() {
-            atom.applicationDelegate.openExternal('http://help.kite.com');
+            notification.dismiss();
+            Kite.toggleAutocorrectSidebar(true);
           },
         }],
       });

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -579,7 +579,7 @@ describe('autocorrect', () => {
                   expect(atom.notifications.addInfo).toHaveBeenCalled();
 
                   const [content, options] = atom.notifications.addInfo.calls[0].args;
-                  expect(content).toEqual('#### Kite code clean-up was just updated\nSome string');
+                  expect(content).toEqual('#### Kite Error Rescue has just been updated\nSome string');
                   expect(options.detail).toEqual('for x in list:\nfor x in list');
                 });
               });


### PR DESCRIPTION
@dbratz1177 

[NOT LAUNCH-BLOCKING]

· change string to Error Rescue
· open autocorrect sidebar instead of going to a help doc

<img width="478" alt="screen shot 2018-03-27 at 14 53 45" src="https://user-images.githubusercontent.com/2061609/37997567-0c6e68b8-31d0-11e8-9641-b4ef5cd8fa25.png">
