### PR TITLE
Rename commands leading to error rescue.

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,7 +14,7 @@ const MAX_PAYLOAD_SIZE = 2 ** 21; // 2097152
 const CONNECT_ERROR_LOCKOUT = 15 * 60;
 
 const AUTOCORRECT_SHOW_SIDEBAR = 'Reopen sidebar';
-const AUTOCORRECT_DONT_SHOW_SIDEBAR = 'Clean up quietly';
+const AUTOCORRECT_DONT_SHOW_SIDEBAR = 'Fix code quietly';
 
 module.exports = {
   CONNECT_ERROR_LOCKOUT,

--- a/lib/elements/kite-autocorrect-sidebar.js
+++ b/lib/elements/kite-autocorrect-sidebar.js
@@ -65,7 +65,7 @@ class KiteAutocorrectSidebar extends HTMLElement {
                 <div class="setting-title">Any time code is fixed:</div>
                 <select type="checkbox" class="form-control">
                   <option value="${AUTOCORRECT_SHOW_SIDEBAR}">Reopen this sidebar</option>
-                  <option value="${AUTOCORRECT_DONT_SHOW_SIDEBAR}">Clean up quietly</option>
+                  <option value="${AUTOCORRECT_DONT_SHOW_SIDEBAR}">Do nothing (fix code quietly)</option>
                 </select>
               </label>
             </div>
@@ -99,13 +99,13 @@ class KiteAutocorrectSidebar extends HTMLElement {
   attachedCallback() {
     this.subscriptions = new CompositeDisposable();
 
-    this.subscriptions.add(atom.config.observe('kite.enableAutocorrect', (v) => {
+    this.subscriptions.add(atom.config.observe('kite.enableErrorRescue', (v) => {
       this.input.checked = v;
       parent(this.input, '.control-group').classList.toggle('checked', this.input.checked);
       parent(this.input, '.settings-view').classList.toggle('autocorrect-enabled', this.input.checked);
     }));
 
-    this.subscriptions.add(atom.config.observe('kite.actionWhenKiteFixesCode', (v) => {
+    this.subscriptions.add(atom.config.observe('kite.actionWhenErrorRescueFixesCode', (v) => {
       this.select.value = v;
     }));
 
@@ -129,11 +129,11 @@ class KiteAutocorrectSidebar extends HTMLElement {
 
     this.subscriptions.add(new DisposableEvent(this.input, 'change', (e) => {
       parent(this.input, '.control-group').classList.toggle('checked', this.input.checked);
-      atom.config.set('kite.enableAutocorrect', this.input.checked);
+      atom.config.set('kite.enableErrorRescue', this.input.checked);
     }));
 
     this.subscriptions.add(new DisposableEvent(this.select, 'change', (e) => {
-      atom.config.set('kite.actionWhenKiteFixesCode', this.select.value);
+      atom.config.set('kite.actionWhenErrorRescueFixesCode', this.select.value);
     }));
 
     this.subscriptions.add(addDelegatedEventListener(this, 'click', '.message-box .btn-close', (e) => {

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -102,7 +102,7 @@ class KiteEditor {
     if (!Kite) { Kite = require('./kite'); }
     if (!metrics) { metrics = require('./metrics'); }
 
-    if (!atom.config.get('kite.enableAutocorrect') || Kite.isSaveAll()) {
+    if (!atom.config.get('kite.enableErrorRescue') || Kite.isSaveAll()) {
       return DataLoader.postSaveValidationData(this.editor).catch(() => {});
     }
 
@@ -165,7 +165,7 @@ class KiteEditor {
   }
 
   mustOpenSidebar() {
-    return atom.config.get('kite.actionWhenKiteFixesCode') === AUTOCORRECT_SHOW_SIDEBAR;
+    return atom.config.get('kite.actionWhenErrorRescueFixesCode') === AUTOCORRECT_SHOW_SIDEBAR;
   }
 
   notifyCodeCleanUpVersionChange(version) {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -274,7 +274,7 @@ module.exports = {
       }));
     }
 
-    this.subscriptions.add(atom.config.onDidChange('kite.actionWhenKiteFixesCode', ({oldValue}) => {
+    this.subscriptions.add(atom.config.onDidChange('kite.actionWhenErrorRescueFixesCode', ({oldValue}) => {
       if (oldValue === AUTOCORRECT_SHOW_SIDEBAR) {
         metrics.sendFeatureMetric('atom_autocorrect_show_panel_disabled');
       } else {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -33,6 +33,9 @@ module.exports = {
       }
     }
 
+    // little thing to take out legacy config name value so it won't show up on settings
+    atom.config.unset('kite.actionWhenKiteFixesCode');
+
     // We store all the subscriptions into a composite disposable to release
     // them on deactivation
     this.subscriptions = new CompositeDisposable();

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "Reopen sidebar",
         "Fix code quietly"
       ],
-      "description": "Show the Error Rescue sidebar whenever it makes changes, or do it in the background."
+      "description": "Choose whether Error Rescue should (re)open its sidebar upon making fixes, or do it quietly"
     },
     "maxVisibleSuggestionsAlongSignature": {
       "type": "integer",

--- a/package.json
+++ b/package.json
@@ -61,19 +61,19 @@
       "default": false,
       "description": "Makes the sidebar appears on startup when enabled."
     },
-    "enableAutocorrect": {
+    "enableErrorRescue": {
       "type": "boolean",
       "default": true,
-      "description": "Enables autocorrect feature on save."
+      "description": "Allow Error Rescue to make code fixes on save"
     },
-    "actionWhenKiteFixesCode": {
+    "actionWhenErrorRescueFixesCode": {
       "type": "string",
       "default": "Reopen sidebar",
       "enum": [
         "Reopen sidebar",
-        "Clean up quietly"
+        "Fix code quietly"
       ],
-      "description": "Makes the autocorrect sidebar appears on save when enabled."
+      "description": "Show the Error Rescue sidebar whenever it makes changes, or do it in the background."
     },
     "maxVisibleSuggestionsAlongSignature": {
       "type": "integer",

--- a/spec/autocorrect-spec.js
+++ b/spec/autocorrect-spec.js
@@ -19,7 +19,7 @@ describe('autocorrect', () => {
 
     localStorage.removeItem('kite.autocorrect_model_version');
 
-    atom.config.set('kite.actionWhenKiteFixesCode', AUTOCORRECT_DONT_SHOW_SIDEBAR);
+    atom.config.set('kite.actionWhenErrorRescueFixesCode', AUTOCORRECT_DONT_SHOW_SIDEBAR);
 
     // Use these styles if you need to display the workspace when running the tests
     // jasmineContent.innerHTML = `
@@ -227,7 +227,7 @@ describe('autocorrect', () => {
                   input.checked = false;
                   input.dispatchEvent(new window.Event('change'));
 
-                  expect(atom.config.get('kite.enableAutocorrect')).toBeFalsy();
+                  expect(atom.config.get('kite.enableErrorRescue')).toBeFalsy();
                 });
               });
 
@@ -332,7 +332,7 @@ describe('autocorrect', () => {
 
             describe('with reopen this sidebar setting', () => {
               beforeEach(() => {
-                atom.config.set('kite.actionWhenKiteFixesCode', AUTOCORRECT_SHOW_SIDEBAR);
+                atom.config.set('kite.actionWhenErrorRescueFixesCode', AUTOCORRECT_SHOW_SIDEBAR);
               });
 
               describe('and the version does not change', () => {
@@ -423,7 +423,7 @@ describe('autocorrect', () => {
 
             describe('with Clean up quietly setting', () => {
               beforeEach(() => {
-                atom.config.set('kite.actionWhenKiteFixesCode', AUTOCORRECT_DONT_SHOW_SIDEBAR);
+                atom.config.set('kite.actionWhenErrorRescueFixesCode', AUTOCORRECT_DONT_SHOW_SIDEBAR);
               });
 
               describe('when the sidebar is open, but not active', () => {
@@ -674,7 +674,7 @@ describe('autocorrect', () => {
             });
           });
 
-          describe('when the actionWhenKiteFixesCode is set to reopen the sidebar', () => {
+          describe('when the actionWhenErrorRescueFixesCode is set to reopen the sidebar', () => {
             let sidebar;
 
             withRoutes([
@@ -685,7 +685,7 @@ describe('autocorrect', () => {
             ]);
 
             beforeEach(() => {
-              atom.config.set('kite.actionWhenKiteFixesCode', AUTOCORRECT_SHOW_SIDEBAR);
+              atom.config.set('kite.actionWhenErrorRescueFixesCode', AUTOCORRECT_SHOW_SIDEBAR);
 
               editor.save();
 


### PR DESCRIPTION
@dbratz1177 

Tested by using them, and by verifying that toggling both options in Kite sidebar also toggles them in the settings.

<img width="768" alt="image" src="https://user-images.githubusercontent.com/2061609/37998212-9912f0e8-31d2-11e8-837a-d7ea729ae85d.png">
