### PR TITLE
Sig caching

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -6,6 +6,8 @@ const Plan = require('./plan');
 const {delayPromise} = require('./utils');
 let Kite;
 
+let cachedBufferPosition;
+
 const KiteProvider = {
   selector: '.source.python, .source.js',
   disableForSelector: [
@@ -26,10 +28,14 @@ const KiteProvider = {
       ? delayPromise(() => {
         let promise = Plan.queryPlan();
         if (this.isInsideFunctionCall(params)) {
-          promise = promise.then(() => this.loadSignature(params));
+          if (this.shouldLoadSignature(params)) {
+            promise = promise.then(() => this.loadSignature(params));
+          }
         } else {
           this.clearSignature();
         }
+
+        cachedBufferPosition = params.bufferPosition;
 
         if (!atom.config.get('kite.enableCompletions', false)) {
           return promise.then(() => []);
@@ -38,7 +44,32 @@ const KiteProvider = {
         return promise.then(() =>
         DataLoader.getCompletionsAtPosition(params.editor, params.editor.getCursorBufferPosition()));
       }, 0)
-      : Promise.resolve();
+      : new Promise((resolve) => {
+        cachedBufferPosition = params.bufferPosition;
+        resolve();
+      });
+  },
+ 
+  shouldLoadSignature({ bufferPosition, editor }) {
+    const prevChars =  bufferPosition.column > 0 ?
+         editor.getTextInBufferRange([[bufferPosition.row, bufferPosition.column - 2], [bufferPosition.row, bufferPosition.column + 1]]) : '';
+    const prevChar = prevChars[1] === ')' ? prevChars[0] : prevChars[1]; // hack around non-intuitive bufferPosition with initial keystroke of '(' and auto-suffixion of ')'
+    const shouldLoad = this.isArgBeginning(bufferPosition, prevChar) || this.keystrokeNonContinuous(bufferPosition, prevChars);
+    return shouldLoad;
+  },
+
+  isArgBeginning(bufferPosition, prevChar) {
+    return /^[(,]+$/.test(prevChar);
+  },
+
+  keystrokeNonContinuous(bufferPosition, prevChars) {
+    if (!cachedBufferPosition) { return true; }
+    if (bufferPosition.row !== cachedBufferPosition.row) { return true; }
+    if (bufferPosition.column === cachedBufferPosition.column + 1) { return false; }
+    if (bufferPosition.column === cachedBufferPosition.column) {
+      if (prevChars[0] === '(' && prevChars[2] && prevChars[2] === ')') { return false; } // hack for detecting first typed char of first arg
+    }
+    return true;
   },
 
   isInsideFunctionCall({scopeDescriptor}) {
@@ -64,6 +95,8 @@ const KiteProvider = {
           ? atom.config.get('autocomplete-plus.maxVisibleSuggestions')
           : atom.config.get('kite.maxVisibleSuggestionsAlongSignature');
 
+        let isNewSigPanel = true;
+        if (this.signaturePanel) { isNewSigPanel = false; }
         this.signaturePanel = this.signaturePanel || new KiteSignature();
         this.signaturePanel.setListElement(listElement);
 
@@ -72,12 +105,15 @@ const KiteProvider = {
           ? this.signaturePanel.setAttribute('no-documentation', '')
           : this.signaturePanel.removeAttribute('no-documentation');
 
-        const element = listElement.element
+        if (isNewSigPanel) {
+          const element = listElement.element
           ? listElement.element
           : listElement;
 
-        element.style.width = null;
-        element.insertBefore(this.signaturePanel, element.lastChild);
+          element.style.width = null;
+        
+          element.insertBefore(this.signaturePanel, element.lastChild);
+        }
       }
     })
     .catch(err => {});

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -105,11 +105,11 @@ const KiteProvider = {
           ? this.signaturePanel.setAttribute('no-documentation', '')
           : this.signaturePanel.removeAttribute('no-documentation');
 
-        if (isNewSigPanel) {
-          const element = listElement.element
+        const element = listElement.element
           ? listElement.element
           : listElement;
 
+        if (isNewSigPanel || this.sigPanelNeedsReinsertion(element)) {
           element.style.width = null;
         
           element.insertBefore(this.signaturePanel, element.lastChild);
@@ -117,6 +117,14 @@ const KiteProvider = {
       }
     })
     .catch(err => {});
+  },
+
+  sigPanelNeedsReinsertion(element) {
+    //TODO: explore this and fill this in
+    for (let i = 0; i < element.children.length; i++) {
+      if (element.children[i].tagName.toLowerCase() === 'kite-signature') { return false; }
+    }
+    return true;
   },
 
   clearSignature() {
@@ -129,7 +137,6 @@ const KiteProvider = {
     if (!atom.packages.getAvailablePackageNames().includes('autocomplete-plus')) {
       return null;
     }
-
     if (this.suggestionListElement) { return this.suggestionListElement; }
 
     const pkg = atom.packages.getActivePackage('autocomplete-plus').mainModule;


### PR DESCRIPTION
Does a couple of things:
- Is more selective when making calls to `clientapi/editor/signature` endpoint. Attempts to somewhat mirror what the behavior is on VSCode. The heuristic is based on detecting chars (`,` and `(` that signal the beginning of an argument) and on non-contiguous keystroke events (i.e. the previously cached bufferPosition is not one before the current bufferPosition)
- Changes the insertion behavior of the `signaturePanel` in order to eliminate flashing behavior (currently, the signature panel will toggle on/off with subsequent `loadSignature` actions)