### PR TITLE
Beep whenever Docs At Cursor are invoked at an invalid place.

### DIFF
--- a/lib/elements/navigable-panel.js
+++ b/lib/elements/navigable-panel.js
@@ -151,7 +151,7 @@ class NavigablePanel extends HTMLElement {
       } else {
         this.emptyData();
       }
-    });
+    }).catch(() => { atom.beep(); });
   }
 
   showDataAtRange(editor, range, noMetrics = false) {


### PR DESCRIPTION
@dhung09 

I think this would make it clearer that the keystroke was registered, but Kite has nothing to say… open to other approaches, though?

See: https://github.com/kiteco/kiteco/issues/5650