### PR TITLE
Add syntax highlighting to places where it's missing.

### DIFF
--- a/lib/kite-data-utils.js
+++ b/lib/kite-data-utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {compact, flatten, head, last, uniq, detailGet, detailNotEmpty, detailLang, getFunctionDetails} = require('./utils');
+const {highlightChunk} = require('./highlighter');
 
 const idIsEmpty = (id) =>
   !id || id === '' ||
@@ -12,8 +13,8 @@ const parameterName = (p, prefix = '', w) =>
   p
     ? (
       w
-        ? `<${w}>${prefix}<span class="parameter-name">${p.name}</span></${head(w.split(/\s/g))}>`
-        : `${prefix}<span class="parameter-name">${p.name}</span>`
+        ? `<${w}>${prefix}<span class="syntax--source"><span class="syntax--variable syntax--parameter syntax--function parameter-name">${p.name}</span></span></${head(w.split(/\s/g))}>`
+        : `${prefix}<span class="syntax--python"><span class="syntax--variable syntax--parameter syntax--function parameter-name">${p.name}</span></span>`
     )
     : undefined;
 
@@ -26,7 +27,8 @@ const parameterDefault = (p) => {
     case 'python':
     case 'javascript':
       return detailNotEmpty(p, 'default_value')
-        ? `=<span class="parameter-default">${head(detailGet(p, 'default_value')).repr}</span>`
+        ? `<span class="syntax--source"><span class="syntax--keyword syntax--operator syntax--assignment">=</span></span>` +
+            `<span class="parameter-default">${highlightChunk(head(detailGet(p, 'default_value')).repr)}</span>`
         : '';
     default:
       return '';
@@ -120,7 +122,7 @@ const valueNameFromId = value =>
 
 const valueLabel = (value, current) =>
   isFunctionKind(value.kind)
-    ? valueName(value) + '(\u200b' + // \u200b = zero-width space
+    ? highlightChunk(valueName(value) + '(') + '\u200b' + // \u200b = zero-width space
       signature(value, false, current) + ')'
     : (value.kind === 'instance'
       ? valueNameFromId(value)

--- a/spec/elements/kite-expand-function-spec.js
+++ b/spec/elements/kite-expand-function-spec.js
@@ -6,6 +6,10 @@ const {reportFromHover} = require('../../lib/kite-data-utils');
 describe('KiteExpandFunction', () => {
   let json, element;
 
+  beforeEach(() => {
+    waitsForPromise(() => atom.packages.activatePackage('language-python'));
+  });
+
   describe('with hover data', () => {
     beforeEach(() => {
       json = require('../fixtures/test/increment.json');


### PR DESCRIPTION
@abe33

Adds syntax highlighting so it’s consistently applied in different places in the plugin.

This is the most versatile I could make it – using Highlighter for as much as necessary, and not ever relying on saying “python.” Would welcome any suggestions if you have on how to make it simpler.

Please note that “true” and “false” are not highlighted properly because of this bug: https://github.com/kiteco/kiteco/issues/5616

PS I don’t know why the test is failing. I spent half an hour looking at it, but I’m not sure if it’s a failure or something specific with the test?

Before:
<img width="439" alt="screen shot 2018-04-25 at 13 35 08" src="https://user-images.githubusercontent.com/2061609/39271334-a088216e-488d-11e8-9db5-973b15de896d.png">

After:
<img width="446" alt="screen shot 2018-04-25 at 13 33 30" src="https://user-images.githubusercontent.com/2061609/39271342-a44384a6-488d-11e8-910f-6118faa4940e.png">

Before:
<img width="436" alt="screen shot 2018-04-25 at 13 34 58" src="https://user-images.githubusercontent.com/2061609/39271319-97762f58-488d-11e8-869d-9d1871799a7e.png">

After:
<img width="433" alt="screen shot 2018-04-25 at 13 33 40" src="https://user-images.githubusercontent.com/2061609/39271326-9d00f106-488d-11e8-942d-84b70af6fa92.png">
