### PR TITLE
Fix status panel settings link

### DIFF
--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -266,7 +266,7 @@ class KiteStatusPanel extends HTMLElement {
       <li><a class="icon icon-question" href="http://help.kite.com/category/43-atom-integration">Help</a></li>
     </ul>
     <ul class="links ${account ? 'has-account' : 'no-account'}">
-      <li><a class="icon icon-settings href="kite-atom-internal://open-settings">Atom Plugin Settings</a></li>
+      <li><a class="icon icon-settings" href="kite-atom-internal://open-settings">Atom Plugin Settings</a></li>
       <li><a class="icon icon-settings account-dependent"
              href="http://localhost:46624/settings">Kite Settings</a></li>
       <li><a class="icon icon-file-directory" href="http://localhost:46624/settings/permissions"


### PR DESCRIPTION
There was a missing double quote breaking the link markup.