### PR TITLE
Hide hovers when cursor moves.

### DIFF
--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -64,6 +64,10 @@ class KiteEditor {
     subs.add(editor.onDidChangeCursorPosition(() => {
       if (!Kite) { Kite = require('./kite'); }
       if (typeof Kite.setStatusLabel === 'function') { Kite.setStatusLabel(this); }
+      if (atom.config.get('kite.enableHoverUI')) {
+        if (!OverlayManager) { OverlayManager = require('./overlay-manager'); }
+        OverlayManager.dismissWithDelay();
+      }
     }));
 
     subs.add(editor.onDidDestroy(() => {


### PR DESCRIPTION
@dhung09 + @dbratz1177 

This hides hover pop-up whenever the cursor moves (and/or the programmer starts typing).

The rationale here is that the hover might be in the way as you type, obscuring your view. (The same logic that explains why Mac OS hides a mouse pointer the moment you start typing.)

Since there is nothing in the hover the programmer would want to type _from,_ I feel there is no downside.

Also, should I try to add a test for this?