### PR TITLE
Better handling of long names in hover and sidebar.

### DIFF
--- a/lib/elements/function-utils.js
+++ b/lib/elements/function-utils.js
@@ -1,4 +1,4 @@
-const {renderParameter, highlightCode, wrapAfterParenthesis, proFeatures, pluralize} = require('./html-utils');
+const {renderParameter, highlightCode, wrapAfterParenthesisAndDots, proFeatures, pluralize} = require('./html-utils');
 const {detailNotEmpty, detailGet, detailLang, getFunctionDetails} = require('../utils');
 const {callSignature} = require('../kite-data-utils');
 const Plan = require('../plan');
@@ -13,7 +13,7 @@ function renderPatterns(data) {
           <section class="patterns">
           <h4>How others used this</h4>
           <div class="section-content">${
-            highlightCode(wrapAfterParenthesis(
+            highlightCode(wrapAfterParenthesisAndDots(
               detail.signatures
               .map(s => callSignature(s))
               .map(s => `${name}(${s})`)

--- a/lib/elements/html-utils.js
+++ b/lib/elements/html-utils.js
@@ -39,8 +39,8 @@ function highlightCode(content) {
 // Helps with intentional text wrapping. HTML is not very well equipped to break code strings in natural places.
 // To get ahead of word-break doing it haphazardly (although we still keep it as a last measure), we’ll insert
 // zero-width spaces in all the right places – the same places a programmer might choose to break to a new line.
-function wrapAfterParenthesis(content) {
-  return content.replace(/\(/g, '(\u200b' /* zero-width space */);
+function wrapAfterParenthesisAndDots(content) {
+  return content.replace(/([\(\.])/g, '$1\u200b' /* zero-width space */);
 }
 
 function stripBody(html) {
@@ -79,7 +79,7 @@ function renderValueHeader(symbol) {
 function renderHeader(name, type) {
   return `
   <div class="expand-header split-line">
-    <span class="name"><code>${name.replace(/\./g, '.&#8203;')}</code></span>
+    <span class="name"><code>${wrapAfterParenthesisAndDots(name)}</code></span>
     <span class="type">${type}</span>
   </div>`;
 }
@@ -227,7 +227,7 @@ function renderUsage(usage) {
 
   return `<div class="usage-container">
     <li class="usage">
-      ${highlightCode(wrapAfterParenthesis(usage.code.trim()))}
+      ${highlightCode(wrapAfterParenthesisAndDots(usage.code.trim()))}
       <div class="links">
         <i class="icon icon-file-code"></i>
         <a href="${url}">${base}<span class="line-colon">:</span>${usage.line}</a>
@@ -408,5 +408,5 @@ module.exports = {
   section,
   symbolDescription,
   valueDescription,
-  wrapAfterParenthesis,
+  wrapAfterParenthesisAndDots,
 };

--- a/lib/elements/html-utils.js
+++ b/lib/elements/html-utils.js
@@ -39,9 +39,13 @@ function highlightCode(content) {
 // Helps with intentional text wrapping. HTML is not very well equipped to break code strings in natural places.
 // To get ahead of word-break doing it haphazardly (although we still keep it as a last measure), we’ll insert
 // zero-width spaces in all the right places – the same places a programmer might choose to break to a new line.
+function wrapAfterParenthesis(content) {
+  return content.replace(/(\()/g, '$1\u200b' /* zero-width space */);
+}
+
+// This seems to affect syntax highlighting somewhat, so shouldn’t be used when syntax highlighting
 function wrapAfterParenthesisAndDots(content) {
-  return content;
-  //return content.replace(/([\(\.])/g, '$1\u200b' /* zero-width space */);
+  return content.replace(/([\(\.])/g, '$1\u200b' /* zero-width space */);
 }
 
 function stripBody(html) {
@@ -228,7 +232,7 @@ function renderUsage(usage) {
 
   return `<div class="usage-container">
     <li class="usage">
-      ${highlightCode(wrapAfterParenthesisAndDots(usage.code.trim()))}
+      ${highlightCode(wrapAfterParenthesis(usage.code.trim()))}
       <div class="links">
         <i class="icon icon-file-code"></i>
         <a href="${url}">${base}<span class="line-colon">:</span>${usage.line}</a>

--- a/lib/elements/html-utils.js
+++ b/lib/elements/html-utils.js
@@ -40,7 +40,8 @@ function highlightCode(content) {
 // To get ahead of word-break doing it haphazardly (although we still keep it as a last measure), we’ll insert
 // zero-width spaces in all the right places – the same places a programmer might choose to break to a new line.
 function wrapAfterParenthesisAndDots(content) {
-  return content.replace(/([\(\.])/g, '$1\u200b' /* zero-width space */);
+  return content;
+  //return content.replace(/([\(\.])/g, '$1\u200b' /* zero-width space */);
 }
 
 function stripBody(html) {

--- a/lib/elements/html-utils.js
+++ b/lib/elements/html-utils.js
@@ -413,5 +413,6 @@ module.exports = {
   section,
   symbolDescription,
   valueDescription,
+  wrapAfterParenthesis,
   wrapAfterParenthesisAndDots,
 };

--- a/lib/elements/kite-hover.js
+++ b/lib/elements/kite-hover.js
@@ -44,7 +44,7 @@ class KiteHover extends HTMLElement {
 
       this.innerHTML = `
     <div class="definition">
-      <span class="name"><code>${symbolName(symbol)}</code></span>
+      <span class="name"><code>${wrapAfterParenthesisAndDots(symbolName(symbol))}</code></span>
       <span class="type">${symbolKind(symbol)}</span>
     </div>
     <kite-links class="one-line" metric="Hover">

--- a/lib/elements/kite-hover.js
+++ b/lib/elements/kite-hover.js
@@ -5,6 +5,7 @@ const {Point} = require('atom');
 const {symbolName, symbolKind, symbolId, idIsEmpty} = require('../kite-data-utils');
 const {debugData} = require('./html-utils');
 const {internalGotoURL, internalExpandPositionURL, internalOpenPositionInWebURL} = require('../urls');
+const {wrapAfterParenthesisAndDots} = require('./html-utils');
 let OverlayManager;
 
 class KiteHover extends HTMLElement {

--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -97,7 +97,6 @@ class KiteSignature extends HTMLElement {
       extendedContent = `
       ${kwargs}
       ${patterns}
-
       <kite-links class="one-line" metric="Signature">
         ${actions.join(' ')}
         <div class="flex-separator"></div>

--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -4,7 +4,7 @@ const {CompositeDisposable} = require('atom');
 const {head, DisposableEvent, detailLang, detailGet, getFunctionDetails} = require('../utils');
 const {openSignatureInWebURL, internalExpandURL} = require('../urls');
 const {valueLabel, valueName, callSignature} = require('../kite-data-utils');
-const {highlightCode, wrapAfterParenthesis, debugData, proFeatures, pluralize, renderParameter} = require('./html-utils');
+const {highlightCode, wrapAfterParenthesisAndDots, debugData, proFeatures, pluralize, renderParameter} = require('./html-utils');
 const Plan = require('../plan');
 
 class KiteSignature extends HTMLElement {
@@ -75,7 +75,7 @@ class KiteSignature extends HTMLElement {
           ? `
             <section class="patterns">
             <h4>How others used this</h4>
-            ${highlightCode(wrapAfterParenthesis(
+            ${highlightCode(wrapAfterParenthesisAndDots(
               call.signatures
               .map(s => callSignature(s))
               .map(s => `${name}(${s})`)

--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -75,7 +75,7 @@ class KiteSignature extends HTMLElement {
           ? `
             <section class="patterns">
             <h4>How others used this</h4>
-            ${highlightCode(wrapAfterParenthesisAndDots(
+            ${highlightCode(wrapAfterParenthesis(
               call.signatures
               .map(s => callSignature(s))
               .map(s => `${name}(${s})`)

--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -4,7 +4,7 @@ const {CompositeDisposable} = require('atom');
 const {head, DisposableEvent, detailLang, detailGet, getFunctionDetails} = require('../utils');
 const {openSignatureInWebURL, internalExpandURL} = require('../urls');
 const {valueLabel, valueName, callSignature} = require('../kite-data-utils');
-const {highlightCode, wrapAfterParenthesisAndDots, debugData, proFeatures, pluralize, renderParameter} = require('./html-utils');
+const {highlightCode, wrapAfterParenthesis, debugData, proFeatures, pluralize, renderParameter} = require('./html-utils');
 const Plan = require('../plan');
 
 class KiteSignature extends HTMLElement {

--- a/spec/elements/kite-hover-spec.js
+++ b/spec/elements/kite-hover-spec.js
@@ -32,7 +32,7 @@ describe('KiteHover', () => {
       it('sets the name of the hover using the provided value', () => {
         const name = hover.querySelector('.name');
 
-        expect(name.textContent).toEqual('Test.increment');
+        expect(name.textContent).toEqual('Test.\u200bincrement');
       });
 
       it('sets the return type of the hover using the provided value', () => {
@@ -50,7 +50,7 @@ describe('KiteHover', () => {
       it('sets the name of the hover using the provided value', () => {
         const name = hover.querySelector('.name');
 
-        expect(name.textContent).toEqual('Test.increment');
+        expect(name.textContent).toEqual('Test.\u200bincrement');
       });
 
       it('uses the kind for the type', () => {

--- a/styles/content.less
+++ b/styles/content.less
@@ -349,6 +349,8 @@
     .name {
       font-size: 1.4em;
 
+      word-break: break-word;
+
       code {
         font-size: inherit;
         color: @text-color;

--- a/styles/kite-hover.less
+++ b/styles/kite-hover.less
@@ -56,12 +56,15 @@ kite-hover {
     line-height: normal;
 
     .name {
+      outline: 1px solid red;
       word-break: break-word;
+      flex: 100;
     }
     .type { // TODO: Opportunity to unify CSS: This is very similar as elsewhere, with the exception of font size and different margins
       font-size: .8em;
       display: inline-block;
       flex: none;
+      outline: 3px solid green;
       padding: .3em .5em;
       line-height: 1.1;
       border: 1px solid @text-color-subtle;

--- a/styles/kite-hover.less
+++ b/styles/kite-hover.less
@@ -56,15 +56,12 @@ kite-hover {
     line-height: normal;
 
     .name {
-      outline: 1px solid red;
       word-break: break-word;
-      flex: 100;
     }
     .type { // TODO: Opportunity to unify CSS: This is very similar as elsewhere, with the exception of font size and different margins
       font-size: .8em;
       display: inline-block;
       flex: none;
-      outline: 3px solid green;
       padding: .3em .5em;
       line-height: 1.1;
       border: 1px solid @text-color-subtle;

--- a/styles/kite-hover.less
+++ b/styles/kite-hover.less
@@ -10,8 +10,16 @@ kite-hover {
   padding-bottom: @component-padding;
   border-radius: @component-border-radius;
   font-family: @font-family;
-  max-width: 600px;
+  max-width: 20em;
   overflow: hidden;
+
+  box-shadow: 0 10px 20px rgba(0, 0, 0, .4);
+
+  animation: fade-in 100ms;
+  @keyframes fade-in {
+    0% { opacity: 0; transform: translate(0, -3px); }
+    100% { opacity: 1; transform: translate(0, 0); }
+  }
 
   code {
     font-family: var(--editor-font-family);
@@ -20,26 +28,6 @@ kite-hover {
 
     padding: 0;
     background: inherit;
-  }
-
-  .type { // TODO: Opportunity to unify CSS: This is very similar as elsewhere, with the exception of font size and different margins
-    font-size: .8em;
-    display: inline-block;
-    flex: 0;
-    padding: .3em .5em;
-    line-height: 1.1;
-    border: 1px solid @text-color-subtle;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, .5);
-    margin-right: -.2em;
-    margin-left: 3em !important;
-  }
-
-  box-shadow: 0 10px 20px rgba(0, 0, 0, .4);
-
-  animation: fade-in 100ms;
-  @keyframes fade-in {
-    0% { opacity: 0; transform: translate(0, -3px); }
-    100% { opacity: 1; transform: translate(0, 0); }
   }
 
   .debug {
@@ -66,6 +54,22 @@ kite-hover {
     flex-direction: row;
     align-items: center;
     line-height: normal;
+
+    .name {
+      word-break: break-word;
+    }
+    .type { // TODO: Opportunity to unify CSS: This is very similar as elsewhere, with the exception of font size and different margins
+      font-size: .8em;
+      display: inline-block;
+      flex: none;
+      padding: .3em .5em;
+      line-height: 1.1;
+      border: 1px solid @text-color-subtle;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, .5);
+      margin-right: -.2em;
+      margin-left: 3em !important;
+    }
+
 
     .type, .signature, a, a:hover, a:focus, a:active {
       color: @text-color;


### PR DESCRIPTION
@dbratz1177 

· Don’t allow the hover to grow too wide since it looks awkward
· Break the hover name on dots as we do in sidebar, and allow it to be broken by the browser
· Allow the sidebar name to be broken by the browser

<img width="522" alt="screen shot 2018-04-27 at 16 32 58" src="https://user-images.githubusercontent.com/2061609/39388974-f3d99cba-4a38-11e8-8e6d-b7df8c58cd17.png">
<img width="513" alt="screen shot 2018-04-27 at 16 33 02" src="https://user-images.githubusercontent.com/2061609/39388975-f3f0726e-4a38-11e8-92af-7a221287f673.png">
<img width="456" alt="screen shot 2018-04-27 at 16 33 10" src="https://user-images.githubusercontent.com/2061609/39388976-f40be580-4a38-11e8-93c6-856b638a558b.png">
