### PR TITLE
Switch Error Rescue color to syntax color + add synthesized syntax color for contrast themes.

### DIFF
--- a/styles/content.less
+++ b/styles/content.less
@@ -1,5 +1,6 @@
 @import "ui-variables";
 @import "variables";
+@import "syntax-highlighting";
 
 .unreachable {
   &, &:hover, &:active, &:focus {

--- a/styles/kite-error-rescue-sidebar.less
+++ b/styles/kite-error-rescue-sidebar.less
@@ -173,7 +173,7 @@ kite-error-rescue-sidebar {
       padding: 4px;
       padding-left: @triple-padding;
       position: relative;
-      color: @text-color;
+      color: @syntax-text-color;
       white-space: pre-wrap;
       word-break: break-word;
 

--- a/styles/syntax-highlighting.less
+++ b/styles/syntax-highlighting.less
@@ -1,0 +1,26 @@
+.kite-code {
+  pre,
+  code {
+    // In case of a user selecting a combination of:
+    // dark UI theme/light syntax theme OR light UI theme/dark syntax theme
+    // using the default syntax colors often makes them unreadable since we
+    // have to output them on the UI background, not the syntax background.
+    // In this case, we synthesize new syntax colors.
+    .synthesized-syntax-color(@syntax-text-color, @tab-background-color);
+  }
+}
+
+.synthesized-syntax-color(@text-color, @background-color)
+    when (((lightness(@text-color) < 50%) and (lightness(@background-color) < 50%)) or
+          ((lightness(@text-color) > 50%) and (lightness(@background-color) > 50%))) {
+  span {
+    color: hsl(hue(@syntax-text-color), saturation(@syntax-text-color),
+           100% - lightness(@background-color)) !important;
+  }
+  .syntax--punctuation, .syntax--punctuation > span,
+  .syntax--constant, .syntax--constant > span,
+  .syntax--keyword, .syntax--keyword > span {
+    color: hsl(hue(@syntax-color-keyword), saturation(@syntax-color-keyword),
+           (150% - lightness(@background-color)) / 2) !important;
+  }
+}


### PR DESCRIPTION
@dbratz1177 

As discussed in a meeting a while back.

After:
· https://github.com/kiteco/atom-plugin/pull/340
· https://github.com/kiteco/atom-plugin/pull/389
· https://github.com/kiteco/kiteco/issues/5735
this finalized syntax highlighting for Atom.

More info/discussion: https://kite.quip.com/ZWgsAdvh9xDq/Syntax-highlighting-in-Atom-Implementation-notes-April-2018