### PR TITLE
Remove soft spaces from one area where syntax highlighting is used.

### DIFF
--- a/lib/elements/function-utils.js
+++ b/lib/elements/function-utils.js
@@ -1,4 +1,4 @@
-const {renderParameter, highlightCode, wrapAfterParenthesisAndDots, proFeatures, pluralize} = require('./html-utils');
+const {renderParameter, highlightCode, wrapAfterParenthesis, proFeatures, pluralize} = require('./html-utils');
 const {detailNotEmpty, detailGet, detailLang, getFunctionDetails} = require('../utils');
 const {callSignature} = require('../kite-data-utils');
 const Plan = require('../plan');
@@ -13,7 +13,7 @@ function renderPatterns(data) {
           <section class="patterns">
           <h4>How others used this</h4>
           <div class="section-content">${
-            highlightCode(wrapAfterParenthesisAndDots(
+            highlightCode(wrapAfterParenthesis(
               detail.signatures
               .map(s => callSignature(s))
               .map(s => `${name}(${s})`)


### PR DESCRIPTION
@dbratz1177 

Before/after:

<img width="403" alt="screen shot 2018-05-03 at 05 36 06" src="https://user-images.githubusercontent.com/2061609/39576727-fd743816-4e93-11e8-92be-e44f62ad0ee1.png">
<img width="402" alt="screen shot 2018-05-03 at 05 35 22" src="https://user-images.githubusercontent.com/2061609/39576726-fd57dd2e-4e93-11e8-8c03-27d189fc06d2.png">

