### PR TITLE
Fix 402

### DIFF
--- a/lib/elements/kite-status.js
+++ b/lib/elements/kite-status.js
@@ -132,7 +132,6 @@ class KiteStatus extends HTMLElement {
         .catch(() => {
           this.statusText && (this.statusText.innerHTML = label);
         });
-        this.lastDocsAtCursorPromise;
       } else {
         this.statusText && (this.statusText.innerHTML = label);
       }

--- a/lib/elements/kite-status.js
+++ b/lib/elements/kite-status.js
@@ -116,7 +116,8 @@ class KiteStatus extends HTMLElement {
         : DataLoader.getHoverDataAtPosition(kiteEditor.editor, pos);
 
         this.lastDocsAtCursorPosition = key;
-        this.lastDocsAtCursorPromise = promise.then(data => {
+        this.lastDocsAtCursorPromise = promise;
+        promise.then(data => {
           const editorElement = kiteEditor.editorElement;
           const binding = atom.keymaps.findKeyBindings({target: editorElement})
           .filter(k => k.command === 'kite:docs-at-cursor')[0];


### PR DESCRIPTION
We were storing the promise along with the continuation and the catch, so when we were reusing the promise it was always resolving, leading to the status always displaying the `Docs available at cursor` message.