### PR TITLE
idIsEmpty should not rely on the string contents

### DIFF
--- a/lib/kite-data-utils.js
+++ b/lib/kite-data-utils.js
@@ -4,8 +4,7 @@ const {compact, flatten, head, last, uniq, detailGet, detailNotEmpty, detailLang
 const {highlightChunk} = require('./highlighter');
 
 const idIsEmpty = (id) =>
-  !id || id === '' ||
-  (id.indexOf(';') !== -1 && id.split(';')[1] === '');
+  !id || id === '';
 
 const isFunctionKind = kind => ['function', 'type'].includes(kind);
 


### PR DESCRIPTION
This is blocking a fix to an important issue with hover not working for top-level packages; that fix changes the ID format slightly. Regardless, this check should no longer be necessary, as we should always return `""` from the API for invalid IDs.

cc @jlozano 