### PR TITLE
Memoize getStatus promise to avoid spamming the endpoint

### DIFF
--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -35,6 +35,8 @@ const metrics = require('./metrics');
 
 const ensureKite = () => { if (!Kite) { Kite = require('./kite'); } };
 
+const pendingStatusRequestByEditor = {};
+
 const DataLoader = {
   isEditorAuthorized(editor) {
     ensureKite();
@@ -209,7 +211,11 @@ const DataLoader = {
     const filepath = editor.getPath();
     const path = statusPath(filepath);
 
-    return promisifyRequest(StateController.client.request({path}))
+    if (pendingStatusRequestByEditor[filepath]) {
+      return pendingStatusRequestByEditor[filepath];
+    }
+
+    return pendingStatusRequestByEditor[filepath] = promisifyRequest(StateController.client.request({path}))
     .then(resp => {
       Logger.logResponse(resp);
       if (resp.statusCode === 200) {
@@ -219,7 +225,11 @@ const DataLoader = {
       }
       return {status: 'ready'};
     })
-    .catch(() => ({status: 'ready'}));
+    .catch(() => ({status: 'ready'}))
+    .then(res => {
+      delete pendingStatusRequestByEditor[filepath];
+      return res;
+    });
   },
 
   getCompletionsAtPosition(editor, position) {


### PR DESCRIPTION
Several part of the plugin can triggers updates of the status bar, which 
will lead to request to the status endpoint. To avoid 3-4 requests in a 
row the first one is stored until receiving the response and shared if 
another request is triggered in the meantime

Closes #445