### PR TITLE
Fix logo flicker when syncing status is displayed

### DIFF
--- a/styles/kite-status.less
+++ b/styles/kite-status.less
@@ -2,6 +2,10 @@
 @import "variables";
 
 kite-status {
+  kite-logo {
+    height: 16px;
+    width: 16px;
+  }
   kite-logo.badge {
     margin: 0px;
     margin-bottom: 3px;


### PR DESCRIPTION
Apparently, our syncing logo, as not displayed initially, was rendered 
using a 0 width and height, making it invisible.

Closes #434