### PR TITLE
Add admin check

### DIFF
--- a/lib/kite-app.js
+++ b/lib/kite-app.js
@@ -241,7 +241,12 @@ class KiteApp {
   installFlow() {
     ensureKiteDeps();
 
-    return KiteAPI.canInstallKite().then((values) => {
+    return Promise.all([
+      KiteAPI.canInstallKite(),
+      localStorage.getItem('kite.no-admin-privileges')
+        ? Promise.reject('User does not have admin privileges')
+        : Promise.resolve(),
+    ]).then(([values]) => {
       Metrics.Tracker.name = 'atom';
       Metrics.Tracker.props = {};
       Metrics.Tracker.props.lastEvent = event;

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -154,13 +154,13 @@ class NotificationsCenter {
         text: 'Learn how to use Kite',
         onDidClick(dismiss) {
           atom.applicationDelegate.openExternal('http://help.kite.com/category/43-atom-integration');
-          dismiss();
+          dismiss && dismiss();
         },
       }, {
         text: "Don't show this again",
         onDidClick(dismiss) {
           atom.config.set('kite.showWelcomeNotificationOnStartup', false);
-          dismiss();
+          dismiss && dismiss();
         },
       }],
     }, {
@@ -186,7 +186,7 @@ class NotificationsCenter {
             metrics.featureRequested('editor_vacancy_notification_install');
             atom.applicationDelegate.openExternal('kite://settings/plugins');
             metrics.featureFulfilled('editor_vacancy_notification_install');
-            dismiss();
+            dismiss && dismiss();
           },
         }, {
           text: 'Never ask again',
@@ -194,7 +194,7 @@ class NotificationsCenter {
             metrics.featureRequested('editor_vacancy_notification_disabled');
             atom.config.set('kite.showEditorVacanciesNotificationOnStartup', false);
             metrics.featureFulfilled('editor_vacancy_notification_disabled');
-            dismiss();
+            dismiss && dismiss();
           },
         }];
 
@@ -277,7 +277,7 @@ Would you like to install Kite for these editors?`,
             onDidClick(dismiss) {
               const Kite = require('./kite');
 
-              dismiss();
+              dismiss && dismiss();
               Kite.toggleErrorRescueSidebar(true);
             },
           }],
@@ -322,7 +322,7 @@ Would you like to install Kite for these editors?`,
             text: 'Install Kite',
             metric: 'install',
             onDidClick: dismiss => {
-              dismiss();
+              dismiss && dismiss();
               this.app && this.app.install();
             },
           }],
@@ -355,14 +355,14 @@ Would you like to install Kite for these editors?`,
               text: 'Start Kite',
               metric: 'start',
               onDidClick: dismiss => {
-                dismiss();
+                dismiss && dismiss();
                 this.app && this.app.start().catch(err => this.warnFailedStart(err));
               },
             }, {
               text: 'Start Kite Enterprise',
               metric: 'startEnterprise',
               onDidClick: dismiss => {
-                dismiss();
+                dismiss && dismiss();
                 this.app && this.app.startEnterprise().catch(err => this.warnFailedStartEnterprise(err));
               },
             }],
@@ -378,7 +378,7 @@ Would you like to install Kite for these editors?`,
               text: 'Start Kite',
               metric: 'start',
               onDidClick: dismiss => {
-                dismiss();
+                dismiss && dismiss();
                 this.app && this.app.start().catch(err => this.warnFailedStart(err));
               },
             }],
@@ -394,7 +394,7 @@ Would you like to install Kite for these editors?`,
               text: 'Start Kite Enterprise',
               metric: 'startEnterprise',
               onDidClick: dismiss => {
-                dismiss();
+                dismiss && dismiss();
                 this.app && this.app.startEnterprise().catch(err => this.warnFailedStartEnterprise(err));
               },
             }],
@@ -413,7 +413,7 @@ Would you like to install Kite for these editors?`,
           text: 'Retry',
           metric: 'retry',
           onDidClick: dismiss => {
-            dismiss();
+            dismiss && dismiss();
             this.app && this.app.start().catch(err => this.warnFailedStart(err));
           },
         }],
@@ -430,7 +430,7 @@ Would you like to install Kite for these editors?`,
           text: 'Retry',
           metric: 'retryEnterprise',
           onDidClick: dismiss => {
-            dismiss();
+            dismiss && dismiss();
             this.app && this.app.startEnterprise().catch(err => this.warnFailedStartEnterprise(err));
           },
         }],
@@ -460,7 +460,7 @@ Would you like to install Kite for these editors?`,
             text: 'Login',
             metric: 'login',
             onDidClick: dismiss => {
-              dismiss();
+              dismiss && dismiss();
               this.app && this.app.login();
             },
           }],
@@ -478,7 +478,7 @@ Would you like to install Kite for these editors?`,
           text: 'Retry',
           metric: 'retry',
           onDidClick: dismiss => {
-            dismiss();
+            dismiss && dismiss();
             this.app && this.app.login();
           },
         }],
@@ -516,7 +516,7 @@ Would you like to install Kite for these editors?`,
           className: 'btn btn-default pull-right',
           onDidClick: dismiss => {
             done();
-            dismiss();
+            dismiss && dismiss();
             const path = encodeURI(editorPath);
             const url = `kite://settings/permissions?filename=${path}&action=blacklist`;
             atom.applicationDelegate.openExternal(url);
@@ -526,7 +526,7 @@ Would you like to install Kite for these editors?`,
           metric: 'enable root',
           onDidClick: dismiss => {
             done();
-            dismiss();
+            dismiss && dismiss();
             this.app && this.app.whitelist(root);
           },
         }, {
@@ -539,7 +539,7 @@ Would you like to install Kite for these editors?`,
 
               if (p) {
                 done();
-                dismiss();
+                dismiss && dismiss();
                 this.app && this.app.whitelist(p);
               }
             });
@@ -580,7 +580,7 @@ Would you like to install Kite for these editors?`,
           text: 'Retry',
           metric: 'retry',
           onDidClick: dismiss => {
-            dismiss();
+            dismiss && dismiss();
             this.app && this.app.whitelist(dirpath);
           },
         }],


### PR DESCRIPTION
Currently this PR doesn't include the kite-installer package bump, as the change only imply to check a local storage value. By using `localStorage.setItem('kite.no-admin-privileges', true)` you can easily emulate the `kite-installer` behaviour for when we've detected the user had no admin privileges.

Once the kite-installer PR would be approved, merged and released I'll update this PR.