### PR TITLE
Do not check editor status in plugin polling

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -225,9 +225,7 @@ const Kite = module.exports = {
     this.patchCompletions();
 
     this.pollingInterval = setInterval(() => {
-      if (atom.workspace.getActiveTextEditor()) {
-        this.checkTextEditor(atom.workspace.getActiveTextEditor(), 'pollingInterval');
-      } else {
+      if (!atom.workspace.getActiveTextEditor()) {
         this.connect('pollingInterval');
       }
     }, atom.config.get('kite.pollingInterval'));


### PR DESCRIPTION
It's already handled in the status and in some conditions, the result of 
having both is that the plugin polling set an invalid status