### PR TITLE
Fix double classes definition in link

### DIFF
--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -271,8 +271,7 @@ class KiteStatusPanel extends HTMLElement {
       ${giftLink}
     </ul>
     <ul class="links ${account ? 'has-account' : 'no-account'}">
-      <li><a class="icon icon-search" href="http://localhost:46624/clientapi/desktoplogin?d=/docs"
-          class="account-dependent">Kite Web Search</a></li>
+      <li><a class="icon icon-search account-dependent" href="http://localhost:46624/clientapi/desktoplogin?d=/docs">Kite Web Search</a></li>
       <li><a class="icon icon-question" href="http://help.kite.com/category/43-atom-integration">Help</a></li>
     </ul>
     <ul class="links ${account ? 'has-account' : 'no-account'}">


### PR DESCRIPTION
The second `class` attribute with the `account-dependent` class was ignored and the link was active when it shouldn't have.

Fixes #500 