### PR TITLE
adds kite: tutorial abilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,6 @@ Kite exposes many commands so that you can setup your own keybindings for them.
 |`kite:permissions`|Opens Kite permissions into the copilot.|
 |`kite:general-settings`|Opens Kite settings into the copilot.|
 |`kite:editor-plugin-settings`|Opens the Kite plugin settings in Atom.|
-|`kite:help`|Open Kite help into your browser.|
+|`kite:help-docs`|Open Kite help docs in your browser.|
 |`kite:status`|Open the Kite status panel.|
 |`kite:tutorial`|Open the Kite interactive onboarding tutorial.|

--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ Kite exposes many commands so that you can setup your own keybindings for them.
 |`kite:editor-plugin-settings`|Opens the Kite plugin settings in Atom.|
 |`kite:help`|Open Kite help into your browser.|
 |`kite:status`|Open the Kite status panel.|
+|`kite:tutorial`|Open the Kite interactive onboarding tutorial.|

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -268,7 +268,7 @@ const Kite = module.exports = {
       'kite:open-copilot': () => this.openCopilot(),
       'kite:editor-plugin-settings': () =>
         atom.applicationDelegate.openExternal('atom://settings-view/show-package?package=kite'),
-      'kite:help': () =>
+      'kite:help-docs': () =>
         atom.applicationDelegate.openExternal('https://help.kite.com/category/43-atom-integration'),
       'kite:status': () => {
         metrics.featureRequested('status_panel');

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -257,6 +257,7 @@ const Kite = module.exports = {
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
       'kite:permissions': () => this.openPermissions(),
+      'kite:tutorial': () => this.openKiteTutorial(),
       'kite:general-settings': () => this.openSettings(),
       'kite:open-copilot': () => this.openCopilot(),
       'kite:editor-plugin-settings': () =>
@@ -566,6 +567,15 @@ const Kite = module.exports = {
   openSettings() {
     const url = 'kite://settings';
     atom.applicationDelegate.openExternal(url);
+  },
+
+  openKiteTutorial() {
+    KiteAPI.getOnboardingFilePath().then(path => {
+      atom.workspace.open(path);
+    })
+    .catch((err) => {
+      this.notifications.warnOboardingFileFailure();
+    });
   },
 
   openCopilot() {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -81,12 +81,6 @@ const Kite = module.exports = {
       atom.config.unset('kite.showDocsNotificationOnStartup');
     }
 
-    //open kite onboarding if flag indicates so
-    if (atom.config.get('kite.showKiteOnboarding')) {
-      atom.config.set('kite.showKiteOnboarding', false);
-      this.openKiteTutorial();
-    }
-
     // We store all the subscriptions into a composite disposable to release
     // them on deactivation
     this.subscriptions = new CompositeDisposable();
@@ -291,6 +285,12 @@ const Kite = module.exports = {
     // We monitor kited health
     this.healthInterval = setInterval(checkHealth, 60 * 1000 * 10);
     checkHealth();
+
+    // onboarding handling
+    //open kite onboarding if flag indicates so
+    if (atom.config.get('kite.showWelcomeNotificationOnStartup')) {
+      this.openKiteTutorial();
+    }
 
     this.notifications.startupNotifications();
     // setTimeout(() => this.startupNotifications(), 500);
@@ -576,11 +576,21 @@ const Kite = module.exports = {
   },
 
   openKiteTutorial() {
-    KiteAPI.getOnboardingFilePath().then(path => {
-      atom.workspace.open(path);
-    })
-    .catch((err) => {
-      this.notifications.warnOboardingFileFailure();
+    KiteAPI.getKiteSetting('has_done_onboarding')
+    .then(hasDone => {
+      if (!hasDone) {
+        KiteAPI.getOnboardingFilePath().then(path => {
+          atom.workspace.open(path);
+          this.notifications.onboardingNotifications(true);
+          KiteAPI.setKiteSetting('has_done_onboarding', true);
+        })
+        .catch((err) => {
+          this.notifications.warnOnboardingFileFailure();
+        });
+      } else {
+        // do welcome notification without onboarding reference
+        this.notifications.onboardingNotifications();
+      }
     });
   },
 

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -81,6 +81,12 @@ const Kite = module.exports = {
       atom.config.unset('kite.showDocsNotificationOnStartup');
     }
 
+    //open kite onboarding if flag indicates so
+    if (atom.config.get('kite.showKiteOnboarding')) {
+      atom.config.set('kite.showKiteOnboarding', false);
+      this.openKiteTutorial();
+    }
+
     // We store all the subscriptions into a composite disposable to release
     // them on deactivation
     this.subscriptions = new CompositeDisposable();

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -589,6 +589,16 @@ Would you like to install Kite for these editors?`,
       });
   }
 
+  warnOboardingFileFailure() {
+    this.queue.addWarning('We we unable to open the tutorial', {
+      description: 'We had an internal error setting up our interactive tutorial. Try again later, or email us at feedback@kite.com',
+      buttons: [{
+        text: 'OK',
+        onDidClick: dismiss => dismiss && dismiss(),
+      }],
+    });
+  }
+
   notifyReady(state) {
     this.queue.addSuccess(
       'The Kite engine is ready', {

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -147,11 +147,15 @@ class NotificationsCenter {
     this[this.NOTIFIERS[state]] && this[this.NOTIFIERS[state]](state);
   }
 
-  startupNotifications() {
+  onboardingNotifications(hasSeenOnboarding) {
+    const description = hasSeenOnboarding
+      ? ''
+      : 'We\'ve set up an interactive tutorial for you, but we have docs to get you started too!'
     this.queue.addInfo('Welcome to Kite for Atom', {
       dismissable: true,
+      description: description,
       buttons: [{
-        text: 'Learn how to use Kite',
+        text: 'Learn more about Kite for Atom',
         onDidClick(dismiss) {
           atom.applicationDelegate.openExternal('http://help.kite.com/category/43-atom-integration');
           dismiss && dismiss();
@@ -168,6 +172,9 @@ class NotificationsCenter {
         fromSetting('kite.showWelcomeNotificationOnStartup'),
         () => !atom.inSpecMode()),
     });
+  }
+
+  startupNotifications() {
 
     this.queue.add(() => {
       if (!atom.config.get('kite.showEditorVacanciesNotificationOnStartup')) {
@@ -589,7 +596,7 @@ Would you like to install Kite for these editors?`,
       });
   }
 
-  warnOboardingFileFailure() {
+  warnOnboardingFileFailure() {
     this.queue.addWarning('We we unable to open the tutorial', {
       description: 'We had an internal error setting up our interactive tutorial. Try again later, or email us at feedback@kite.com',
       buttons: [{

--- a/package.json
+++ b/package.json
@@ -28,14 +28,8 @@
     "showWelcomeNotificationOnStartup": {
       "type": "boolean",
       "default": true,
-      "title": "Show welcome notification on startup",
-      "description": "Whether to display the Kite welcome notification on startup"
-    },
-    "showKiteOnboarding": {
-      "type": "boolean",
-      "default": true,
-      "title": "Show interactive onboarding tutorial on startup",
-      "description": "Whether to show the Kite interactive onboarding tutorial on startup"
+      "title": "Show welcome features on startup",
+      "description": "Whether to display the Kite welcome features on startup"
     },
     "showEditorVacanciesNotificationOnStartup": {
       "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,12 @@
       "title": "Show welcome notification on startup",
       "description": "Whether to display the Kite welcome notification on startup"
     },
+    "showKiteOnboarding": {
+      "type": "boolean",
+      "default": true,
+      "title": "Show interactive onboarding tutorial on startup",
+      "description": "Whether to show the Kite interactive onboarding tutorial on startup"
+    },
     "showEditorVacanciesNotificationOnStartup": {
       "type": "boolean",
       "default": true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
-    "kite-api": "^2.0.5",
+    "kite-api": "kiteco/kite-api-js#onboarding-file-endpoint",
     "kite-connector": "^2.0.1",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
-    "kite-api": "^2.0.6",
+    "kite-api": "^2.1.0",
     "kite-connector": "^2.0.1",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
-    "kite-api": "kiteco/kite-api-js#onboarding-file-endpoint",
+    "kite-api": "^2.0.6",
     "kite-connector": "^2.0.1",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",


### PR DESCRIPTION
dependent on https://github.com/kiteco/kiteco/pull/6656 and https://github.com/kiteco/kite-api-js/pull/6 getting merged first

This adds the `Kite: Tutorial` feature for interactive onboarding. This will eventually replicated in other editors, and will be also eventually started via the Copilot at the end of onboarding
