### PR TITLE
Use and escape text documentation instead of html

### DIFF
--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -3,6 +3,7 @@
 const {internalExpandURL} = require('./urls');
 const KiteAPI = require('kite-api');
 const metrics = require('./metrics');
+const {escapeHTML} = require('./highlighter');
 
 const pendingStatusRequestByEditor = {};
 
@@ -77,10 +78,7 @@ const DataLoader = {
           displayText: c.display,
           type: c.hint,
           rightLabel: c.hint,
-          descriptionHTML: this.appendCompletionsFooter(c,
-            c.documentation_html !== ''
-              ? c.documentation_html
-              : c.documentation_text),
+          descriptionHTML: this.appendCompletionsFooter(c, escapeHTML(c.documentation_text)),
         };
       });
     });


### PR DESCRIPTION
HTML examples in the documentation are not escaped, leading to invalid 
display.