### PR TITLE
Move documentation above signature

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -133,7 +133,7 @@ const KiteProvider = {
         if (isNewSigPanel || this.sigPanelNeedsReinsertion(element)) {
           element.style.width = null;
 
-          element.insertBefore(this.signaturePanel, element.lastChild);
+          element.appendChild(this.signaturePanel);
         }
       } else {
         this.clearSignature();

--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -3,6 +3,7 @@
 const {internalExpandURL} = require('./urls');
 const KiteAPI = require('kite-api');
 const metrics = require('./metrics');
+const {escapeHTML} = require('./highlighter');
 
 const pendingStatusRequestByEditor = {};
 
@@ -77,10 +78,7 @@ const DataLoader = {
           displayText: c.display,
           type: c.hint,
           rightLabel: c.hint,
-          descriptionHTML: this.appendCompletionsFooter(c,
-            c.documentation_html !== ''
-              ? c.documentation_html
-              : c.documentation_text),
+          descriptionHTML: this.appendCompletionsFooter(c, escapeHTML(c.documentation_text)),
         };
       });
     });

--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -78,6 +78,7 @@ const DataLoader = {
           displayText: c.display,
           type: c.hint,
           rightLabel: c.hint,
+          description: c.documentation_text,
           descriptionHTML: this.appendCompletionsFooter(c, escapeHTML(c.documentation_text)),
         };
       });

--- a/lib/data-loader.js
+++ b/lib/data-loader.js
@@ -78,7 +78,7 @@ const DataLoader = {
           displayText: c.display,
           type: c.hint,
           rightLabel: c.hint,
-          description: c.documentation_text,
+          description: c.documentation_text || 'kite',
           descriptionHTML: this.appendCompletionsFooter(c, escapeHTML(c.documentation_text)),
         };
       });

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -681,8 +681,6 @@ const Kite = module.exports = {
             }
           }
 
-          console.log(item);
-
           if (item && item.descriptionHTML) {
             listElement.descriptionContainer.classList.add('kite-completions');
             listElement.descriptionContent.innerHTML = item.descriptionHTML;

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -651,6 +651,15 @@ const Kite = module.exports = {
 
         manager.displaySuggestions = (suggestions, options) => {
           if (element.querySelector('kite-signature')) {
+            const desc = element.querySelector('.suggestion-description');
+            if (desc) {
+              if (suggestions.length === 0) {
+                desc.style.display = 'none';
+              } else {
+                desc.style.display = '';
+              }
+            }
+
             if (parseFloat(autocompletePlus.metadata.version) >= 2.36) {
               manager.showSuggestionList(manager.getUniqueSuggestions(suggestions, s => s.text), options);
             } else {
@@ -672,9 +681,9 @@ const Kite = module.exports = {
             }
           }
 
-          if (listElement.descriptionContainer.style.display === 'none' &&
-              item && item.descriptionHTML) {
-            listElement.descriptionContainer.style.display = 'block';
+          console.log(item);
+
+          if (item && item.descriptionHTML) {
             listElement.descriptionContainer.classList.add('kite-completions');
             listElement.descriptionContent.innerHTML = item.descriptionHTML;
 

--- a/styles/kite-signature.less
+++ b/styles/kite-signature.less
@@ -18,7 +18,6 @@ kite-signature {
 
   .kite-signature-wrapper {
     margin: 0;
-    margin-left: 30px;
   }
 
   pre {

--- a/styles/kite.less
+++ b/styles/kite.less
@@ -88,7 +88,8 @@ atom-text-editor .kite-hyperclick {
 }
 
 autocomplete-suggestion-list.select-list.popover-list .suggestion-description.kite-completions {
-  padding: 0 @component-padding @component-padding;
+  padding: @component-padding;
+  padding-top: @half-padding;
   overflow: visible;
 }
 

--- a/styles/kite.less
+++ b/styles/kite.less
@@ -88,9 +88,8 @@ atom-text-editor .kite-hyperclick {
 }
 
 autocomplete-suggestion-list.select-list.popover-list .suggestion-description.kite-completions {
-  padding-right: @component-padding;
+  padding: 0 @component-padding @component-padding;
   overflow: visible;
-  padding-bottom: @component-padding;
 }
 
 atom-text-editor[data-grammar="source python"] .autocomplete-suggestion-list.select-list.popover-list .kite-completions .suggestion-description-content {

--- a/styles/kite.less
+++ b/styles/kite.less
@@ -88,7 +88,6 @@ atom-text-editor .kite-hyperclick {
 }
 
 autocomplete-suggestion-list.select-list.popover-list .suggestion-description.kite-completions {
-  padding-left: 2.8em;
   padding-right: @component-padding;
   overflow: visible;
   padding-bottom: @component-padding;


### PR DESCRIPTION
Includes the changes discussed in the quip docs. 

- [x] Fix for unescaped HTML
- [x] Moving the completions item docs above the function signature panel
- [x] Removing the left-padding in the content of the completions item docs and function signature panel
- [x] Fix to remove docs of last selected completions item from the function signature panel

