### PR TITLE
css class naming typo

### DIFF
--- a/styles/kite.less
+++ b/styles/kite.less
@@ -55,7 +55,7 @@
   background-image: url('atom://kite/assets/icon-gift.png');
 }
 
-.platfor-win32 .icon-kite-gift::before {
+.platform-win32 .icon-kite-gift::before {
   background-image: url('atom://kite/assets/icon-gift-windows.png');
 }
 


### PR DESCRIPTION
Found this while I was reading through the plugin styles