### PR TITLE
Close suggestions on signature request ending with no data

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -147,10 +147,7 @@ const KiteProvider = {
   },
 
   sigPanelNeedsReinsertion(element) {
-    for (let i = 0; i < element.children.length; i++) {
-      if (element.children[i].tagName.toLowerCase() === 'kite-signature') { return false; }
-    }
-    return true;
+    return !element.querySelector('kite-signature');
   },
 
   clearSignature() {

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -138,9 +138,11 @@ const KiteProvider = {
       } else {
         this.clearSignature();
       }
+      return data != null;
     })
     .catch(err => {
       this.clearSignature();
+      return false;
     });
   },
 
@@ -158,7 +160,10 @@ const KiteProvider = {
   },
 
   isSignaturePanelVisible() {
-    return this.signaturePanel && this.signaturePanel.parentNode;
+    const listElement = this.getSuggestionsListElement();
+    const element = listElement.element || listElement;
+    return element && element.querySelector('kite-signature');
+    // return this.signaturePanel && this.signaturePanel.parentNode;
   },
 
   getSuggestionsListElement() {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -651,7 +651,7 @@ const Kite = module.exports = {
           const editor = atom.workspace.getActiveTextEditor();
           if (typeof editor !== 'undefined') {
             const position = editor.getCursorBufferPosition();
-            if (element.querySelector('kite-sigature')
+            if (completions.isSignaturePanelVisible()
                 && (completions.isInsideFunctionCall(editor, position)
                 || completions.isOnFunctionCallBrackets(editor, position))) {
               manager.suggestionList.changeItems(null);

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -651,8 +651,9 @@ const Kite = module.exports = {
           const editor = atom.workspace.getActiveTextEditor();
           if (typeof editor !== 'undefined') {
             const position = editor.getCursorBufferPosition();
-            if (completions.isInsideFunctionCall(editor, position)
-                || completions.isOnFunctionCallBrackets(editor, position)) {
+            if (element.querySelector('kite-sigature')
+                && (completions.isInsideFunctionCall(editor, position)
+                || completions.isOnFunctionCallBrackets(editor, position))) {
               manager.suggestionList.changeItems(null);
               element.querySelector('.suggestion-description').style.display = 'none';
             } else {
@@ -673,7 +674,12 @@ const Kite = module.exports = {
               && completions.isSignaturePanelVisible()) {
 
             manager.suggestionList.changeItems(null);
-            completions.loadSignature({editor, position});
+            element.querySelector('.suggestion-description').style.display = 'none';
+            completions.loadSignature({editor, position}).then(shown => {
+              if (!shown) {
+                safeHide.call();
+              }
+            });
             // refresh sig
           } else {
             safeCursorMoved.call(manager, event);


### PR DESCRIPTION
By hacking on the hide suggestion list and cursor moved functions we 
need to account for the response of the signature endpoint to properly 
hide the list when there's no signature data and no suggestions.
Fixes #522