### PR TITLE
Refactor kite editors management

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -23,7 +23,8 @@ const KiteProvider = {
     // console.log('suggestions requested',
     //   Kite.isEditorWhitelisted(params.editor),
     //   Kite.app.isGrammarSupported(params.editor));
-    return Kite.isEditorWhitelisted(params.editor) && Kite.app.isGrammarSupported(params.editor)
+    const editors = Kite.getModule('editors');
+    return editors.isEditorWhitelisted(params.editor) && editors.isGrammarSupported(params.editor)
       ? delayPromise(() => {
         let promise = Plan.queryPlan();
         const position = params.editor.getCursorBufferPosition();

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const {CompositeDisposable} = require('atom');
+const KiteAPI = require('kite-api');
+const {flatten, compact} = require('./utils');
+const DataLoader = require('./data-loader');
+const KiteEditor = require('./kite-editor');
+
+const EXTENSIONS_BY_LANGUAGES = {
+  python: [
+    'py',
+  ],
+  javascript: [
+    'js',
+  ],
+};
+
+module.exports = class KiteEditors {
+  init(kite) {
+    this.Kite = kite;
+    this.subscriptions = new CompositeDisposable();
+    this.kiteEditorByEditorID = [];
+    this.whitelistedEditorByID = [];
+
+    this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
+      if (this.isGrammarSupported(editor)) {
+        this.subscribeToEditor(editor);
+      }
+    }));
+
+    this.subscriptions.add(KiteAPI.onDidDetectWhitelistedPath(path => {
+      this.getEditorsForPath(path).forEach(e => {
+        this.whitelistedEditorByID[e.id] = true;
+      });
+    }));
+
+    this.subscriptions.add(KiteAPI.onDidDetectNonWhitelistedPath(path => {
+      this.getEditorsForPath(path).forEach(e => {
+        this.whitelistedEditorByID[e.id] = false;
+      });
+    }));
+
+    return DataLoader.getSupportedLanguages().then(languages => {
+      this.supportedLanguages = languages;
+    });
+  }
+
+  dispose() {
+    delete this.kiteEditorByEditorID;
+    this.subscriptions && this.subscriptions.dispose();
+  }
+
+  subscribeToEditor(editor) {
+    // We don't want to subscribe twice to the same editor
+    if (!this.hasEditorSubscription(editor)) {
+      const kiteEditor = new KiteEditor(editor);
+      this.kiteEditorByEditorID[editor.id] = kiteEditor;
+
+      this.subscriptions.add(kiteEditor);
+
+      const disposable = editor.onDidDestroy(() => {
+        this.unsubscribeFromEditor(editor);
+        this.subscriptions.remove(disposable);
+      });
+
+      this.subscriptions.add(disposable);
+    }
+  }
+
+  unsubscribeFromEditor(editor) {
+    if (!this.hasEditorSubscription(editor)) { return; }
+
+    const kiteEditor = this.kiteEditorByEditorID[editor.id];
+    kiteEditor.dispose();
+    this.subscriptions.remove(kiteEditor);
+    delete this.kiteEditorByEditorID[editor.id];
+    delete this.whitelistedEditorByID[editor.id];
+  }
+
+  hasEditorSubscription(editor) {
+    return this.kiteEditorForEditor(editor) != null;
+  }
+
+  kiteEditorForEditor(editor) {
+    return editor && this.kiteEditorByEditorID && this.kiteEditorByEditorID[editor.id];
+  }
+
+  getSupportedLanguages() {
+    return this.supportedLanguages;
+  }
+
+  isEditorWhitelisted(editor) {
+    return editor && this.whitelistedEditorByID && this.whitelistedEditorByID[editor.id];
+  }
+
+  isGrammarSupported(editor) {
+    return this.supportedLanguages
+      ? new RegExp(this.getSupportedLanguagesRegExp(this.supportedLanguages))
+            .test(editor.getPath() || '')
+      : /\.py$/.test(editor.getPath() || '');
+  }
+
+  getSupportedLanguagesRegExp(languages) {
+    return `\.(${
+      compact(flatten(languages.map(l => EXTENSIONS_BY_LANGUAGES[l]))).join('|')
+    })$`;
+  }
+
+  getEditorsForPath(path) {
+    return atom.workspace.getPaneItems().filter(i => i && i.getURI && i.getURI() === path);
+  }
+};

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -119,6 +119,15 @@ module.exports = class KiteEditors {
     return editor && this.whitelistedEditorByID && this.whitelistedEditorByID[editor.id];
   }
 
+  hasSupportedFileOpen() {
+    return atom.workspace.getTextEditors().some((e) => this.isGrammarSupported(e));
+  }
+
+  hasActiveSupportedFile() {
+    const editor = atom.workspace.getActiveTextEditor();
+    return editor && this.isGrammarSupported(editor);
+  }
+
   isGrammarSupported(editor) {
     return this.supportedLanguages
       ? new RegExp(this.getSupportedLanguagesRegExp(this.supportedLanguages))

--- a/lib/editors.js
+++ b/lib/editors.js
@@ -21,10 +21,36 @@ module.exports = class KiteEditors {
     this.subscriptions = new CompositeDisposable();
     this.kiteEditorByEditorID = [];
     this.whitelistedEditorByID = [];
+    this.pathSubscriptionsByEditorID = {};
 
     this.subscriptions.add(atom.workspace.observeTextEditors(editor => {
+      // The grammar is known and supported, we cann subscribe to that editor
       if (this.isGrammarSupported(editor)) {
         this.subscribeToEditor(editor);
+      }
+
+      // We still want to know when an editor path changes so we can check
+      // if it is now supported/unsupported
+      if (!this.pathSubscriptionsByEditorID[editor.id]) {
+        const sub = new CompositeDisposable();
+        const dispose = () => {
+          sub.dispose();
+          delete this.pathSubscriptionsByEditorID[editor.id];
+          this.subscriptions.remove(sub);
+        };
+        this.subscriptions.add(sub);
+
+        sub.add(editor.onDidChangePath(() => {
+          if (this.isGrammarSupported(editor)) {
+            this.subscribeToEditor(editor);
+          } else if (this.hasEditorSubscription(editor)) {
+            this.unsubscribeFromEditor(editor);
+          }
+        }));
+
+        sub.add(editor.onDidDestroy(() => dispose()));
+
+        this.pathSubscriptionsByEditorID[editor.id] = sub;
       }
     }));
 

--- a/lib/elements/kite-links.js
+++ b/lib/elements/kite-links.js
@@ -30,7 +30,7 @@ class KiteLinks extends HTMLElement {
     this.subscriptions.add(this.scheme.onDidClickLink(({url, target}) => {
       if (!Kite) { Kite = require('../kite'); }
       const editor = atom.workspace.getActiveTextEditor();
-      const kiteEditor = Kite.kiteEditorForEditor(editor);
+      const kiteEditor = Kite.getModule('editors').kiteEditorForEditor(editor);
       switch (url.host) {
         case 'open-settings':
           atom.applicationDelegate.openExternal('atom://settings-view/show-package?package=kite');

--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -167,12 +167,12 @@ class KiteStatusPanel extends HTMLElement {
         promise = this.app.whitelist(url.path.replace(/^\//, ''))
         .then(() => {
           const editor = atom.workspace.getActiveTextEditor();
-          const kiteEditor = this.app.kite.kiteEditorForEditor(editor);
+          const kiteEditor = this.app.kite.getModule('editors').kiteEditorForEditor(editor);
 
           if (kiteEditor) {
             return kiteEditor.initialize();
           } else {
-            return this.app.kite.subscribeToEditor(editor);
+            return this.app.kite.getModule('editors').subscribeToEditor(editor);
           }
 
         });
@@ -220,7 +220,7 @@ class KiteStatusPanel extends HTMLElement {
       DataLoader.getUserAccountInfo().catch(() => {}),
       DataLoader.getStatus(editor),
     ];
-    if (editor && this.app.isGrammarSupported(editor)) {
+    if (editor && this.app.kite.getModule('editors').isGrammarSupported(editor)) {
       promises.push(DataLoader.projectDirForEditor(editor).catch(() => null));
       promises.push(DataLoader.shouldOfferWhitelist(editor).catch(() => null));
     }
@@ -364,9 +364,9 @@ class KiteStatusPanel extends HTMLElement {
         const editor = atom.workspace.getActiveTextEditor();
         if (!editor) {
           content = `<div>Open a supported file to see Kite's status ${dot}</div>`;
-        } else if (!this.app.isGrammarSupported(editor)) {
+        } else if (!this.app.kite.getModule('editors').isGrammarSupported(editor)) {
           content = `<div>Open a supported file to see Kite's status ${dot}</div>`;
-        } else if (this.app.kite.isEditorWhitelisted(editor)) {
+        } else if (this.app.kite.getModule('editors').isEditorWhitelisted(editor)) {
           if (editor && editor.getText().length >= MAX_FILE_SIZE) {
             content = `
             <div class="text-warning">The current file is too large for Kite to handle ${dot}</div>`;

--- a/lib/elements/kite-status.js
+++ b/lib/elements/kite-status.js
@@ -84,7 +84,7 @@ class KiteStatus extends HTMLElement {
 
     this.subscriptions.add(this.app.onDidGetState(({ state }) => {
       if (this.updateOnGetState) {
-        this.setState(state, this.app.hasActiveSupportedFile());
+        this.setState(state, this.app.kite.getModule('editors').hasActiveSupportedFile());
       }
     }));
 
@@ -146,7 +146,7 @@ class KiteStatus extends HTMLElement {
     this.clearStatusPolling();
 
     if (editor) {
-      const kiteEditor = this.Kite.kiteEditorForEditor(editor);
+      const kiteEditor = this.Kite.getModule('editors').kiteEditorForEditor(editor);
       this.setStatusLabel(kiteEditor);
     }
 

--- a/lib/elements/kite-status.js
+++ b/lib/elements/kite-status.js
@@ -146,7 +146,7 @@ class KiteStatus extends HTMLElement {
     this.clearStatusPolling();
 
     if (editor) {
-      const kiteEditor = this.Kite.kiteEditorByEditorID[editor.id];
+      const kiteEditor = this.Kite.kiteEditorForEditor(editor);
       this.setStatusLabel(kiteEditor);
     }
 

--- a/lib/kite-app.js
+++ b/lib/kite-app.js
@@ -1,8 +1,7 @@
 'use strict';
 
-let os, path, Emitter, Logger, Errors, Metrics,
-  KiteLogin, Plan, parseJSON, promisifyReadResponse, localconfig,
-  errors, flatten, compact, DataLoader, NodeClient, KiteAPI;
+let os, path, Emitter, Logger, Errors, Metrics, Plan, promisifyReadResponse,
+  localconfig, errors, flatten, compact, NodeClient, KiteAPI;
 
 const ensureKiteDeps = () => {
   if (!KiteAPI) {
@@ -16,14 +15,12 @@ const ensureKiteDeps = () => {
 
 const ensureUtils = () => {
   if (!promisifyReadResponse) {
-    ({parseJSON, promisifyReadResponse, flatten, compact} = require('./utils'));
+    ({promisifyReadResponse, flatten, compact} = require('./utils'));
   }
 };
 
 const ATTEMPTS = 30;
 const INTERVAL = 2500;
-const INVALID_PASSWORD = 6;
-const PASSWORD_LESS_USER = 9;
 
 const EXTENSIONS_BY_LANGUAGES = {
   python: [
@@ -32,14 +29,6 @@ const EXTENSIONS_BY_LANGUAGES = {
   javascript: [
     'js',
   ],
-};
-
-const catchResponse = err => {
-  if (err.data && err.data.response) {
-    return err.data.response;
-  } else {
-    throw err;
-  }
 };
 
 class KiteApp {
@@ -221,23 +210,6 @@ class KiteApp {
     });
   }
 
-  connectWithLanguages(src) {
-    if (!DataLoader) { DataLoader = require('./data-loader'); }
-
-    return this.connect(src).then(state => {
-      if (state >= KiteAPI.STATES.REACHABLE) {
-        return DataLoader.getSupportedLanguages()
-        .then(languages => [state, languages])
-        .catch(() => [state, ['python']]);
-      } else {
-        return [state, ['python']];
-      }
-    }).then(([s, l]) => {
-      this.supportedLanguages = l;
-      return s;
-    });
-  }
-
   installFlow() {
     ensureKiteDeps();
 
@@ -413,15 +385,17 @@ class KiteApp {
   }
 
   hasSupportedFileOpen() {
-    return atom.workspace.getTextEditors().some(this.isGrammarSupported);
+    console.log('deprecated function hasSupportedFileOpen called from', new Error().stack);
+    return this.kite.getModule('editors').hasSupportedFileOpen();
   }
 
   hasActiveSupportedFile() {
-    const editor = atom.workspace.getActiveTextEditor();
-    return editor && this.isGrammarSupported(editor);
+    console.log('deprecated function hasActiveSupportedFile called from', new Error().stack);
+    return this.kite.getModule('editors').hasActiveSupportedFile();
   }
 
   isGrammarSupported(editor) {
+    console.log('deprecated function isGrammarSupported called from', new Error().stack);
     return this.supportedLanguages
       ? new RegExp(this.getSupportedLanguagesRegExp(this.supportedLanguages))
             .test(editor.getPath() || '')

--- a/lib/kite-app.js
+++ b/lib/kite-app.js
@@ -384,24 +384,6 @@ class KiteApp {
       : os.homedir();
   }
 
-  hasSupportedFileOpen() {
-    console.log('deprecated function hasSupportedFileOpen called from', new Error().stack);
-    return this.kite.getModule('editors').hasSupportedFileOpen();
-  }
-
-  hasActiveSupportedFile() {
-    console.log('deprecated function hasActiveSupportedFile called from', new Error().stack);
-    return this.kite.getModule('editors').hasActiveSupportedFile();
-  }
-
-  isGrammarSupported(editor) {
-    console.log('deprecated function isGrammarSupported called from', new Error().stack);
-    return this.supportedLanguages
-      ? new RegExp(this.getSupportedLanguagesRegExp(this.supportedLanguages))
-            .test(editor.getPath() || '')
-      : /\.py$/.test(editor.getPath() || '');
-  }
-
   getSupportedLanguagesRegExp(languages) {
     ensureUtils();
     return `\.(${

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let Kite, DataLoader, OverlayManager, WordHoverGesture,
+let Kite, DataLoader, OverlayManager, WordHoverGesture, EditorEvents,
   screenPositionForMouseEvent,
   pixelPositionForMouseEvent, CompositeDisposable,
   metrics;
@@ -12,7 +12,7 @@ class KiteEditor {
     this.editorElement = atom.views.getView(editor);
     this.fixesHistory = [];
 
-    this.subscribeToEditor();
+    this.subscribeToEditor(editor);
   }
 
   dispose() {
@@ -23,18 +23,24 @@ class KiteEditor {
     delete this.buffer;
   }
 
-  subscribeToEditor() {
+  subscribeToEditor(editor) {
     if (!CompositeDisposable) {
       ({CompositeDisposable} = require('atom'));
       ({screenPositionForMouseEvent, pixelPositionForMouseEvent} = require('./utils'));
       WordHoverGesture = require('./gestures/word-hover');
       DataLoader = require('./data-loader');
+      EditorEvents = require('./editor-events');
     }
 
-    const editor = this.editor;
     const subs = new CompositeDisposable();
 
     this.subscriptions = subs;
+    this.events = new EditorEvents(editor);
+    subs.add(this.events);
+
+    if (editor === atom.workspace.getActiveTextEditor()) {
+      this.events.focus();
+    }
 
     this.hoverGesture = new WordHoverGesture(editor, {
       ignoredSelector: 'atom-overlay, atom-overlay *',
@@ -63,11 +69,6 @@ class KiteEditor {
       }
     }));
 
-    subs.add(editor.onDidDestroy(() => {
-      if (!Kite) { Kite = require('./kite'); }
-      Kite.unsubscribeFromEditor(editor);
-    }));
-
     subs.add(editor.getBuffer().onWillSave(() => {
       if (!Kite) { Kite = require('./kite'); }
       if (Kite.isEditorWhitelisted(this.editor)) {
@@ -75,12 +76,6 @@ class KiteEditor {
       }
       return null;
     }));
-  }
-
-  initialize() {
-    return this.editor === atom.workspace.getActivePaneItem()
-      ? DataLoader.isEditorAuthorized(this.editor)
-      : Promise.resolve();
   }
 
   willSaveHook() {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -6,7 +6,7 @@
 let child_process, CompositeDisposable, TextEditor, AccountManager,
   Logger, completions, metrics, KiteApp,
   KiteStatus, KiteStatusPanel, NotificationsCenter,
-  RollbarReporter, OverlayManager, KiteEditor, DataLoader,
+  RollbarReporter, OverlayManager, KiteEditors, DataLoader,
   DisposableEvent, Disposable, EditorEvents, KiteAPI, VirtualCursor, NodeClient, KiteConnect;
 
 const Kite = module.exports = {
@@ -70,6 +70,7 @@ const Kite = module.exports = {
       RollbarReporter = require('./rollbar-reporter');
       metrics = require('./metrics.js');
       DataLoader = require('./data-loader');
+      KiteEditors = require('./editors');
     }
 
     metrics.featureRequested('starting');
@@ -96,10 +97,11 @@ const Kite = module.exports = {
       }));
     }
 
+    this.registerModule('editors', new KiteEditors());
+
     this.subscriptions.add(KiteAPI.onDidDetectWhitelistedPath(path => {
       const status = this.getStatusItem();
       this.getEditorsForPath(path).forEach(e => {
-        this.whitelistedEditorIDs[e.id] = true;
         status.setState(KiteApp.STATES.WHITELISTED, true, e);
       });
     }));
@@ -108,7 +110,6 @@ const Kite = module.exports = {
       const status = this.getStatusItem();
 
       this.getEditorsForPath(path).forEach(e => {
-        this.whitelistedEditorIDs[e.id] = false;
         status.setState(KiteApp.STATES.AUTHENTICATED, true, e);
         DataLoader.shouldOfferWhitelist(e)
         .then(res => {
@@ -123,13 +124,6 @@ const Kite = module.exports = {
     this.subscriptions.add(KiteAPI.onDidFailRequest(err => {
       // TODO
     }));
-
-    // This helps to track to which editor we've actually
-    // subscribed
-    this.pathSubscriptionsByEditorID = {};
-    this.whitelistedEditorIDs = {};
-    this.kiteEditorByEditorID = {};
-    this.eventsByEditorID = {};
 
     // run "apm upgrade kite"
     this.selfUpdate();
@@ -364,10 +358,7 @@ const Kite = module.exports = {
       // python file and we're authenticated
       if (supported) {
         if (state >= KiteApp.STATES.AUTHENTICATED) {
-          this.registerEditorEvents(editor);
-
-          return this.subscribeToEditor(editor)
-          .then(() => [
+          return Promise.resolve([
             this.isEditorWhitelisted(editor) ? KiteApp.STATES.WHITELISTED : state,
             supported,
           ])
@@ -375,57 +366,38 @@ const Kite = module.exports = {
             return [state, supported];
           });
         } else {
-          this.unsubscribeFromEditor(editor);
           return Promise.resolve([state, supported]);
         }
       } else {
-        this.unsubscribeFromEditor(editor);
         return Promise.resolve([state, supported]);
       }
     });
 
-    if (!this.pathSubscriptionsByEditorID[editor.id]) {
-      const sub = new CompositeDisposable();
-      const dispose = () => {
-        sub.dispose();
-        delete this.pathSubscriptionsByEditorID[editor.id];
-        this.subscriptions.remove(sub);
-      };
-      this.subscriptions.add(sub);
-
-      sub.add(editor.onDidChangePath(() => {
-        check(editor);
-        dispose();
-      }));
-
-      sub.add(editor.onDidDestroy(() => dispose()));
-      this.pathSubscriptionsByEditorID[editor.id] = sub;
-    }
     return editor.getPath()
       ? check(editor, src)
       : Promise.reject();
   },
-
-  handle403Response(editor, resp) {
-    if (!DataLoader) { DataLoader = require('./data-loader'); }
-
-    const status = this.getStatusItem();
-    if (resp.statusCode === 403) {
-      this.whitelistedEditorIDs[editor.id] = false;
-      status.setState(KiteApp.STATES.AUTHENTICATED, true, editor);
-      DataLoader.shouldOfferWhitelist(editor)
-      .then(res => {
-        if (res) {
-          this.notifications.warnNotWhitelisted(editor, res);
-        }
-        // if (res && this.notifications.shouldNotify(editor.getPath())) {}
-      })
-      .catch(err => console.error(err));
-    } else {
-      this.whitelistedEditorIDs[editor.id] = true;
-      status.setState(KiteApp.STATES.WHITELISTED, true, editor);
-    }
-  },
+  //
+  // handle403Response(editor, resp) {
+  //   if (!DataLoader) { DataLoader = require('./data-loader'); }
+  //
+  //   const status = this.getStatusItem();
+  //   if (resp.statusCode === 403) {
+  //     this.whitelistedEditorIDs[editor.id] = false;
+  //     status.setState(KiteApp.STATES.AUTHENTICATED, true, editor);
+  //     DataLoader.shouldOfferWhitelist(editor)
+  //     .then(res => {
+  //       if (res) {
+  //         this.notifications.warnNotWhitelisted(editor, res);
+  //       }
+  //       // if (res && this.notifications.shouldNotify(editor.getPath())) {}
+  //     })
+  //     .catch(err => console.error(err));
+  //   } else {
+  //     this.whitelistedEditorIDs[editor.id] = true;
+  //     status.setState(KiteApp.STATES.WHITELISTED, true, editor);
+  //   }
+  // },
 
   deactivate() {
     this.disposeModules();
@@ -527,42 +499,19 @@ const Kite = module.exports = {
     return completions;
   },
 
-  subscribeToEditor(editor) {
-    if (!KiteEditor) { KiteEditor = require('./kite-editor'); }
-    let kiteEditor;
-    // We don't want to subscribe twice to the same editor
-    if (!this.hasEditorSubscription(editor)) {
-      kiteEditor = new KiteEditor(editor);
-      this.kiteEditorByEditorID[editor.id] = kiteEditor;
-
-      this.subscriptions.add(kiteEditor);
-      return Promise.resolve();
-      // return kiteEditor.initialize();
-    } else {
-      if (!DataLoader) { DataLoader = require('./data-loader'); }
-      return Promise.resolve();
-    }
-
-  },
-
-  unsubscribeFromEditor(editor) {
-    if (!this.hasEditorSubscription(editor)) { return; }
-    const kiteEditor = this.kiteEditorByEditorID[editor.id];
-    kiteEditor.dispose();
-    this.subscriptions.remove(kiteEditor);
-    delete this.kiteEditorByEditorID[editor.id];
-  },
-
   kiteEditorForEditor(editor) {
-    return editor ? this.kiteEditorByEditorID[editor.id] : null;
+    console.log('deprecated function kiteEditorForEditor called from', new Error().stack);
+    return this.getModule('editors').kiteEditorForEditor(editor);
   },
 
   hasEditorSubscription(editor) {
-    return this.kiteEditorForEditor(editor) != null;
+    console.log('deprecated function hasEditorSubscription called from', new Error().stack);
+    return this.getModule('editors').hasEditorSubscription(editor);
   },
 
   isEditorWhitelisted(editor) {
-    return this.whitelistedEditorIDs[editor.id];
+    console.log('deprecated function isEditorWhitelisted called from', new Error().stack);
+    return this.getModule('editors').isEditorWhitelisted(editor);
   },
 
   openPermissions() {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -163,7 +163,7 @@ const Kite = module.exports = {
     // need to subscribe to these editors as well
     this.subscriptions.add(this.app.onKiteReady(() => {
       atom.workspace.getTextEditors()
-      .filter(e => this.app.isGrammarSupported(e))
+      .filter(e => this.getModule('editors').isGrammarSupported(e))
       .forEach(e => {
         if (!DisposableEvent) { ({DisposableEvent} = require('./utils')); }
 
@@ -309,13 +309,7 @@ const Kite = module.exports = {
     this.lastExpandAtCursorHighlight = null;
 
     // We try to connect at startup
-    this.app.connectWithLanguages('activation').then(state => {
-      if (state === KiteApp.STATES.UNSUPPORTED) {
-        if (!KiteAPI.isOSSupported()) {
-        } else if (!KiteAPI.isOSVersionSupported()) {
-        }
-      }
-
+    this.app.connect('activation').then(state => {
       if (state === KiteApp.STATES.UNINSTALLED && !this.app.wasInstalledOnce()) {
         this.app.installFlow();
       } else if (state !== KiteApp.STATES.UNINSTALLED) {
@@ -353,13 +347,15 @@ const Kite = module.exports = {
     //src and from act to pass into connect the named of the context in which
     //the function was called, so that connect can handle error state appropriately
     const check = (editor, from) => this.app.connect(from).then(state => {
-      const supported = this.app.isGrammarSupported(editor);
+      const supported = this.getModule('editors').isGrammarSupported(editor);
       // we only subscribe to the editor if it's a
       // python file and we're authenticated
       if (supported) {
         if (state >= KiteApp.STATES.AUTHENTICATED) {
           return Promise.resolve([
-            this.isEditorWhitelisted(editor) ? KiteApp.STATES.WHITELISTED : state,
+            this.getModule('editors').isEditorWhitelisted(editor)
+              ? KiteApp.STATES.WHITELISTED
+              : state,
             supported,
           ])
           .catch(err => {
@@ -377,27 +373,6 @@ const Kite = module.exports = {
       ? check(editor, src)
       : Promise.reject();
   },
-  //
-  // handle403Response(editor, resp) {
-  //   if (!DataLoader) { DataLoader = require('./data-loader'); }
-  //
-  //   const status = this.getStatusItem();
-  //   if (resp.statusCode === 403) {
-  //     this.whitelistedEditorIDs[editor.id] = false;
-  //     status.setState(KiteApp.STATES.AUTHENTICATED, true, editor);
-  //     DataLoader.shouldOfferWhitelist(editor)
-  //     .then(res => {
-  //       if (res) {
-  //         this.notifications.warnNotWhitelisted(editor, res);
-  //       }
-  //       // if (res && this.notifications.shouldNotify(editor.getPath())) {}
-  //     })
-  //     .catch(err => console.error(err));
-  //   } else {
-  //     this.whitelistedEditorIDs[editor.id] = true;
-  //     status.setState(KiteApp.STATES.WHITELISTED, true, editor);
-  //   }
-  // },
 
   deactivate() {
     this.disposeModules();

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -88,7 +88,6 @@ const Kite = module.exports = {
 
     if (!atom.inSpecMode()) {
       this.subscriptions.add(atom.config.observe('kite.developerMode', value => {
-        console.log(value, KiteConnect.client, KiteConnect.client instanceof NodeClient);
         if (value && KiteConnect.client instanceof NodeClient) {
           KiteConnect.toggleRequestDebug();
         } else if (!value && !(KiteConnect.client instanceof NodeClient)) {
@@ -472,21 +471,6 @@ const Kite = module.exports = {
   completions() {
     if (!completions) { completions = require('./completions'); }
     return completions;
-  },
-
-  kiteEditorForEditor(editor) {
-    console.log('deprecated function kiteEditorForEditor called from', new Error().stack);
-    return this.getModule('editors').kiteEditorForEditor(editor);
-  },
-
-  hasEditorSubscription(editor) {
-    console.log('deprecated function hasEditorSubscription called from', new Error().stack);
-    return this.getModule('editors').hasEditorSubscription(editor);
-  },
-
-  isEditorWhitelisted(editor) {
-    console.log('deprecated function isEditorWhitelisted called from', new Error().stack);
-    return this.getModule('editors').isEditorWhitelisted(editor);
   },
 
   openPermissions() {

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -150,7 +150,7 @@ class NotificationsCenter {
   onboardingNotifications(hasSeenOnboarding) {
     const description = hasSeenOnboarding
       ? ''
-      : 'We\'ve set up an interactive tutorial for you, but we have docs to get you started too!'
+      : 'We\'ve set up an interactive tutorial for you, but we have docs to get you started too!';
     this.queue.addInfo('Welcome to Kite for Atom', {
       dismissable: true,
       description: description,
@@ -619,7 +619,7 @@ Would you like to install Kite for these editors?`,
 
   shouldNotify(state) {
     return this.forceNotification ||
-          ((this.app && this.app.hasActiveSupportedFile()) &&
+          ((this.app && this.app.kite.getModule('editors').hasActiveSupportedFile()) &&
            !this.lastShown[state] &&
            !this.paused);
   }

--- a/spec/editors-spec.js
+++ b/spec/editors-spec.js
@@ -219,6 +219,43 @@ describe('editors module', () => {
       });
     });
 
+    describe('.hasSupportedFileOpen()', () => {
+      beforeEach(() => {
+        waitsForPromise(() => module.init());
+      });
+
+      describe('when a suported file is open', () => {
+        it('returns true', () => {
+          expect(module.hasSupportedFileOpen()).toBeFalsy();
+          waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));
+          runs(() => {
+            expect(module.hasSupportedFileOpen()).toBeTruthy();
+          });
+        });
+      });
+    });
+
+    describe('.hasActiveSupportedFile()', () => {
+      beforeEach(() => {
+        waitsForPromise(() => module.init());
+      });
+
+      describe('when a suported file is open', () => {
+        it('returns true', () => {
+          expect(module.hasActiveSupportedFile()).toBeFalsy();
+          waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));
+          runs(() => {
+            expect(module.hasActiveSupportedFile()).toBeTruthy();
+          });
+          waitsForPromise(() => atom.workspace.open('hello.json').then(e => { editor = e; }));
+          runs(() => {
+            expect(module.hasActiveSupportedFile()).toBeFalsy();
+          });
+        });
+      });
+    });
+
+
     describe('on dispose', () => {
       beforeEach(() => {
         waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));

--- a/spec/editors-spec.js
+++ b/spec/editors-spec.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const KiteAPI = require('kite-api');
+const {withKite, withKiteRoutes, withKitePaths} = require('kite-api/test/helpers/kite');
+const {fakeResponse} = require('kite-api/test/helpers/http');
+const KiteEditors = require('../lib/editors');
+const {languagesPath} = require('../lib/urls');
+const {sleep} = require('./spec-helpers');
+
+fdescribe('editors module', () => {
+  let module, editor, unsupportedEditor;
+
+  beforeEach(() => {
+    module = new KiteEditors();
+
+    spyOn(KiteAPI, 'request').andCallThrough();
+  });
+
+  withKite({logged: true}, () => {
+    withKiteRoutes([
+      [
+        o => o.path === languagesPath(),
+        o => fakeResponse(200, '["python"]'),
+      ],
+    ]);
+    beforeEach(() => {
+      waitsForPromise(() => atom.packages.activatePackage('kite'));
+    });
+
+    describe('on initialize', () => {
+      it('makes a request to get the supported languages', () => {
+        waitsForPromise(() => module.init());
+
+        runs(() => {
+          expect(KiteAPI.request).toHaveBeenCalledWith({path: languagesPath()});
+          expect(module.getSupportedLanguages()).toEqual(['python']);
+        });
+      });
+      describe('with no editors open', () => {
+        beforeEach(() => {
+          waitsForPromise(() => module.init());
+        });
+
+        it('registers to new editors event and create kite editors for supported files', () => {
+          waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
+            editor = e;
+          }));
+
+          runs(() => {
+            expect(module.kiteEditorForEditor(editor)).not.toBeUndefined();
+          });
+
+          waitsForPromise(() => atom.workspace.open('hello.json').then(e => {
+            unsupportedEditor = e;
+          }));
+
+          runs(() => {
+            expect(module.kiteEditorForEditor(unsupportedEditor)).toBeUndefined();
+          });
+        });
+      });
+
+      describe('with editors open', () => {
+        beforeEach(() => {
+          waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));
+          waitsForPromise(() => atom.workspace.open('hello.json').then(e => { unsupportedEditor = e; }));
+          waitsForPromise(() => module.init());
+        });
+
+        it('creates kite editors for supported files', () => {
+          expect(module.kiteEditorForEditor(editor)).not.toBeUndefined();
+          expect(module.kiteEditorForEditor(unsupportedEditor)).toBeUndefined();
+        });
+      });
+
+      describe('with supported editors', () => {
+        beforeEach(() => {
+          waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));
+          waitsForPromise(() => module.init());
+        });
+
+        it('sends a focus event for an active supported file', () => {
+          advanceClock(10);
+          sleep(50);
+          runs(() => {
+            const buffer = editor.getBuffer();
+            const cursorOffset = buffer.characterIndexForPosition(editor.getCursorBufferPosition());
+
+            expect(KiteAPI.request).toHaveBeenCalledWith({
+              path: '/clientapi/editor/event',
+              method: 'POST',
+            }, JSON.stringify({
+              source: 'atom',
+              action: 'focus',
+              filename: editor.getPath(),
+              text: editor.getText(),
+              selections: [{
+                start: cursorOffset,
+                end: cursorOffset,
+              }],
+            }));
+          });
+        });
+
+        it('sets the file whitelist state to undefined until it gets a response from kited', () => {
+          expect(module.isEditorWhitelisted(editor)).toBeUndefined();
+        });
+
+        describe('when the editor is destroyed', () => {
+          beforeEach(() => {
+            editor.destroy();
+          });
+
+          it('unsubscribe from the editor events', () => {
+            expect(module.kiteEditorForEditor(editor)).toBeUndefined();
+          });
+        });
+
+        describe('for a whitelisted file', () => {
+          withKitePaths({
+            whitelist: [__dirname],
+          }, undefined, () => {
+            beforeEach(() => {
+              advanceClock(10);
+              sleep(50);
+            });
+
+            it('register the file as whitelisted', () => {
+              expect(module.isEditorWhitelisted(editor)).toBeTruthy();
+            });
+
+            describe('when the editor is destroyed', () => {
+              beforeEach(() => {
+                editor.destroy();
+              });
+
+              it('resets the whitelist state for that editor', () => {
+                expect(module.isEditorWhitelisted(editor)).toBeUndefined();
+              });
+            });
+          });
+        });
+
+        describe('for a non whitelisted file', () => {
+          withKitePaths({whitelist: []}, undefined, () => {
+            beforeEach(() => {
+              advanceClock(10);
+              sleep(50);
+            });
+
+            it('register the file as whitelisted', () => {
+              expect(module.isEditorWhitelisted(editor)).toBe(false);
+            });
+          });
+        });
+      });
+    });
+
+    describe('on dispose', () => {
+      beforeEach(() => {
+        waitsForPromise(() => atom.workspace.open('sample.py').then(e => { editor = e; }));
+        waitsForPromise(() => atom.workspace.open('hello.json').then(e => { unsupportedEditor = e; }));
+        waitsForPromise(() => module.init());
+      });
+
+      it('unsubscribes from all registered editors', () => {
+        module.dispose();
+
+        expect(module.kiteEditorForEditor(editor)).toBeUndefined();
+        expect(module.kiteEditorForEditor(unsupportedEditor)).toBeUndefined();
+      });
+    });
+  });
+});

--- a/spec/elements/kite-links-spec.js
+++ b/spec/elements/kite-links-spec.js
@@ -27,7 +27,6 @@ describe('KiteLinks', () => {
         }));
         waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
           editor = e;
-          Kite.subscribeToEditor(e);
         }));
         waitsFor(() => kiteEditor = Kite.kiteEditorForEditor(editor));
       });

--- a/spec/elements/kite-links-spec.js
+++ b/spec/elements/kite-links-spec.js
@@ -28,7 +28,7 @@ describe('KiteLinks', () => {
         waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
           editor = e;
         }));
-        waitsFor(() => kiteEditor = Kite.kiteEditorForEditor(editor));
+        waitsFor(() => kiteEditor = Kite.getModule('editors').kiteEditorForEditor(editor));
       });
 
       describe('for internal goto urls', () => {

--- a/spec/elements/kite-status-spec.js
+++ b/spec/elements/kite-status-spec.js
@@ -4,13 +4,22 @@ const {withKite, withKitePaths} = require('kite-api/test/helpers/kite');
 
 const KiteApp = require('../../lib/kite-app');
 const KiteStatus = require('../../lib/elements/kite-status');
+const KiteEditors = require('../../lib/editors');
 
 describe('KiteStatus', () => {
-  let status, app;
+  let status, app, editors;
 
   beforeEach(() => {
     app = new KiteApp();
     status = new KiteStatus();
+    editors = new KiteEditors();
+    app.kite = {
+      getModule(mod) {
+        if (mod === 'editors') {
+          return editors;
+        }
+      },
+    };
     status.setApp(app);
 
     document.body.appendChild(status);

--- a/spec/json/actions/new_file.js
+++ b/spec/json/actions/new_file.js
@@ -19,7 +19,7 @@ module.exports = (action, testData) => {
     if (testData.setup.kited === 'authenticated') {
       waitsFor('kite editor', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.kiteEditorForEditor(editor), 50);
+      Kite.getModule('editors').kiteEditorForEditor(editor), 50);
 
       waitsFor('kite whitelist state', () =>
       !/\.py$/.test(action.properties.file) ||

--- a/spec/json/actions/new_file.js
+++ b/spec/json/actions/new_file.js
@@ -23,7 +23,7 @@ module.exports = (action, testData) => {
 
       waitsFor('kite whitelist state', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.whitelistedEditorIDs[editor.id] != undefined, 50);
+      Kite.getModule('editors').whitelistedEditorByID[editor.id] != undefined, 50);
     }
   });
 };

--- a/spec/json/actions/open.js
+++ b/spec/json/actions/open.js
@@ -18,7 +18,7 @@ module.exports = (action, testData) => {
     if (testData.setup.kited === 'authenticated') {
       waitsFor('kite editor', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.kiteEditorForEditor(editor), 500);
+      Kite.getModule('editors').kiteEditorForEditor(editor), 50);
 
       waitsFor('kite whitelist state', () =>
       !/\.py$/.test(action.properties.file) ||

--- a/spec/json/actions/open.js
+++ b/spec/json/actions/open.js
@@ -22,7 +22,7 @@ module.exports = (action, testData) => {
 
       waitsFor('kite whitelist state', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.whitelistedEditorIDs[editor.id] != undefined, 500);
+      Kite.getModule('editors').whitelistedEditorByID[editor.id] != undefined, 50);
     }
   });
 };

--- a/spec/json/actions/request_hover.js
+++ b/spec/json/actions/request_hover.js
@@ -5,7 +5,7 @@ const Kite = require('../../../lib/kite');
 module.exports = (action) => {
   beforeEach(() => {
     const editor = atom.workspace.getActiveTextEditor();
-    const kiteEditor = Kite.kiteEditorForEditor(editor);
+    const kiteEditor = Kite.getModule('editors').kiteEditorForEditor(editor);
 
     if (kiteEditor) {
       kiteEditor.hoverGesture.emitter.emit('did-activate', {position: editor.getCursorBufferPosition()});

--- a/spec/kite-spec.js
+++ b/spec/kite-spec.js
@@ -214,7 +214,7 @@ describe('Kite', () => {
                 waitsForPromise(() => atom.workspace.open('sample.py').then(e => {
                   editor = e;
                 }));
-                waitsFor('kite editor', () => kitePkg.kiteEditorForEditor(editor));
+                waitsFor('kite editor', () => kitePkg.getModule('editors').kiteEditorForEditor(editor));
                 runs(() => {
                   const v = atom.views.getView(editor);
                   v.dispatchEvent(new Event('focus'));
@@ -228,7 +228,7 @@ describe('Kite', () => {
               });
 
               it('subscribes to the editor events', () => {
-                expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+                expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
               });
             });
 
@@ -271,7 +271,7 @@ describe('Kite', () => {
                   });
 
                   it('subscribes to the editor events', () => {
-                    expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+                    expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
                   });
                 });
 
@@ -306,7 +306,7 @@ describe('Kite', () => {
                 const v = atom.views.getView(editor);
                 v.dispatchEvent(new Event('focus'));
               });
-              waitsFor('kite editor', () => kitePkg.kiteEditorForEditor(editor));
+              waitsFor('kite editor', () => kitePkg.getModule('editors').kiteEditorForEditor(editor));
               runs(() => {
                 advanceClock(200);
                 advanceClock(100);
@@ -322,7 +322,7 @@ describe('Kite', () => {
             it('subscribes to the editor events', () => {
               sleep(100);
               runs(() => {
-                expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+                expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
               });
             });
           });
@@ -374,7 +374,7 @@ describe('Kite', () => {
                 });
 
                 it('subscribes to the editor events', () => {
-                  expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+                  expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
                 });
               });
 
@@ -445,7 +445,7 @@ describe('Kite', () => {
                     sleep(100);
                     runs(() => {
                       const editor = atom.workspace.getActiveTextEditor();
-                      expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+                      expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
                     });
                   });
                 });
@@ -481,7 +481,7 @@ describe('Kite', () => {
                 const v = atom.views.getView(editor);
                 v.dispatchEvent(new Event('focus'));
               });
-              waitsFor('kite editor', () => kitePkg.kiteEditorForEditor(editor));
+              waitsFor('kite editor', () => kitePkg.getModule('editors').kiteEditorForEditor(editor));
               runs(() => advanceClock(200));
             });
 
@@ -490,7 +490,7 @@ describe('Kite', () => {
             });
 
             it('subscribes to the editor events', () => {
-              expect(kitePkg.hasEditorSubscription(editor)).toBeTruthy();
+              expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeTruthy();
             });
 
             describe('when the file path is changed', () => {
@@ -504,7 +504,7 @@ describe('Kite', () => {
                 it('unsubscribes from the editor events', () => {
                   sleep(100);
                   runs(() => {
-                    expect(kitePkg.hasEditorSubscription(editor)).toBeFalsy();
+                    expect(kitePkg.getModule('editors').hasEditorSubscription(editor)).toBeFalsy();
                   });
                 });
               });

--- a/spec/notifications-center-spec.js
+++ b/spec/notifications-center-spec.js
@@ -5,6 +5,7 @@ const {withKite, withKitePaths} = require('kite-api/test/helpers/kite');
 
 const NotificationsCenter = require('../lib/notifications-center');
 const KiteApp = require('../lib/kite-app');
+const KiteEditors = require('../lib/editors');
 const {sleep} = require('./spec-helpers');
 const {click} = require('./helpers/events');
 
@@ -28,6 +29,14 @@ describe('NotificationsCenter', () => {
 
   beforeEach(() => {
     app = new KiteApp();
+    const editors = new KiteEditors();
+    app.kite = {
+      getModule(mod) {
+        if (mod === 'editors') {
+          return editors;
+        }
+      },
+    };
     notifications = new NotificationsCenter(app);
 
     workspaceElement = atom.views.getView(atom.workspace);

--- a/spec/signature-plus-completions-spec.js
+++ b/spec/signature-plus-completions-spec.js
@@ -57,7 +57,7 @@ describe('signature + completion', () => {
           }));
 
         waitsFor('kite editor', () =>
-          Kite.kiteEditorForEditor(editor));
+          Kite.getModule('editors').kiteEditorForEditor(editor));
 
         waitsFor('kite whitelist state', () =>
           Kite.getModule('editors').whitelistedEditorByID[editor.id] != undefined);

--- a/spec/signature-plus-completions-spec.js
+++ b/spec/signature-plus-completions-spec.js
@@ -60,7 +60,7 @@ describe('signature + completion', () => {
           Kite.kiteEditorForEditor(editor));
 
         waitsFor('kite whitelist state', () =>
-          Kite.whitelistedEditorIDs[editor.id] != undefined);
+          Kite.getModule('editors').whitelistedEditorByID[editor.id] != undefined);
 
         runs(() => {
           editor.setCursorBufferPosition([2, Number.POSITIVE_INFINITY]);


### PR DESCRIPTION
This pull request introduces a new module that encapsulates the management of Atom's text editors. 

This module now regroups functions that were splitted between the main module and the app object. 

Some parts are still messy  (i.e. when accessing the editors modules through the kite property of the app object in the status) and at the moment the `KiteEditor` class does too little and can problably be merged with the `EditorEvents` one so as to have only one object listening to editor's events, but that will be the scope of next PRs.