### PR TITLE
updates atom live onboarding

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -576,27 +576,39 @@ const Kite = module.exports = {
   },
 
   openKiteTutorial(fromCommand) {
-    KiteAPI.getKiteSetting('has_done_onboarding')
-    .then(hasDone => {
-      if (!hasDone) {
-        KiteAPI.getOnboardingFilePath().then(path => {
-          atom.workspace.open(path);
-          this.notifications.onboardingNotifications(true);
-          KiteAPI.setKiteSetting('has_done_onboarding', true);
-        })
-        .catch((err) => {
-          this.notifications.warnOnboardingFileFailure();
-        });
-      } else {
-        // do welcome notification without onboarding reference
-        this.notifications.onboardingNotifications();
-      }
-    })
-    .catch(err => {
-      if (fromCommand) {
+    if (fromCommand) {
+      KiteAPI.getOnboardingFilePath().then(path => {
+        atom.workspace.open(path);
+      })
+      .catch((err) => {
         this.notifications.warnOnboardingFileFailure();
-      }
-    });
+      });
+    } else {
+      KiteAPI.isKiteLocal().then(isLocal => {
+        if (isLocal) {
+          // then attempt live onboarding
+          KiteAPI.getKiteSetting('has_done_onboarding')
+          .then(hasDone => {
+            if (!hasDone) {
+              KiteAPI.getOnboardingFilePath().then(path => {
+                atom.workspace.open(path);
+                this.notifications.onboardingNotifications();
+                KiteAPI.setKiteSetting('has_done_onboarding', true);
+              })
+              .catch((err) => {
+                this.notifications.warnOnboardingFileFailure();
+              });
+            } else {
+              // do welcome notification without onboarding reference
+              this.notifications.onboardingNotifications(true);
+            }
+          });
+        } else {
+          // do welcome notification without onboarding reference
+          this.notifications.onboardingNotifications(true);
+        }
+      });
+    }
   },
 
   openCopilot() {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
-    "kite-api": "kiteco/kite-api-js#adds-kite-local",
+    "kite-api": "^2.2.0",
     "kite-connector": "^2.0.1",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
-    "kite-api": "^2.1.0",
+    "kite-api": "kiteco/kite-api-js#adds-kite-local",
     "kite-connector": "^2.0.1",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",


### PR DESCRIPTION
updates to handle `KITE_LOCAL` vs. non-`KITE_LOCAL` case
relies on https://github.com/kiteco/kite-api-js/pull/10, so will have to change `package.json` accordingly when that's merged