### PR TITLE
Implement support for kited-test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
 before_script:
   - curl --silent -L "https://s3-us-west-1.amazonaws.com/kite-data/tensorflow/libtensorflow-cpu-`go env GOOS`-x86_64-1.9.0.tar.gz" | tar -C $HOME -xz
   - export LD_LIBRARY_PATH="$HOME/lib:$LD_LIBRARY_PATH"
-  - curl --silent --compressed --output "$HOME/kited-test" "https://s3-us-west-1.amazonaws.com/kited-test/macOS/kited-test"
+  - curl --silent --compressed --output "$HOME/kited-test" "https://s3-us-west-1.amazonaws.com/kited-test/darwin/kited-test"
   - chmod u+x "$HOME/kited-test"
   - $HOME/kited-test > ~/kited-test.log 2>&1 & sleep 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ notifications:
     on_success: never
     on_failure: change
 
+before_script:
+  - curl --silent -L "https://s3-us-west-1.amazonaws.com/kite-data/tensorflow/libtensorflow-cpu-`go env GOOS`-x86_64-1.9.0.tar.gz" | tar -C $HOME -xz
+  - export LD_LIBRARY_PATH="$HOME/lib:$LD_LIBRARY_PATH"
+  - curl --silent --compressed --output "$HOME/kited-test" "https://s3-us-west-1.amazonaws.com/kited-test/macOS/kited-test"
+  - chmod u+x "$HOME/kited-test"
+  - $HOME/kited-test > ~/kited-test.log 2>&1 & sleep 10
+
 script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
 git:
@@ -20,6 +27,7 @@ os:
 
 env:
   global:
+  - LIVE_ENVIRONMENT=1
   - APM_TEST_PACKAGES=""
   - CC=gcc-4.8 CXX=g++-4.8
 

--- a/lib/editor-events.js
+++ b/lib/editor-events.js
@@ -125,7 +125,7 @@ class EditorEvents {
       text = '';
     }
 
-    return this.makeEvent(action, this.editor.getPath(), text, cursorOffset);
+    return this.makeEvent(action, this.editor.getPath(), text, action === 'skip' ? 0 : cursorOffset);
   }
 
   makeEvent(action, filename, text, cursor) {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "getmac": "1.2.1",
     "kite-installer": "^3.0.1",
     "kite-api": "^2.2.0",
-    "kite-connector": "^2.0.1",
+    "kite-connector": "^2.0.3",
     "md5": "^2.2.0",
     "rollbar": "^2.3.8",
     "underscore-plus": "^1",
@@ -128,6 +128,6 @@
     "fbjs": "^0.8.6",
     "javascript-obfuscator": "^0.8.3",
     "sinon": "^2.3.5",
-    "editors-json-tests": "git://github.com/kiteco/editors-json-tests.git#master"
+    "editors-json-tests": "git://github.com/kiteco/editors-json-tests.git#kite-int-testing"
   }
 }

--- a/spec/json-runner-spec.js
+++ b/spec/json-runner-spec.js
@@ -6,9 +6,9 @@ const KiteConnect = require('kite-connector');
 
 const {withKite, withKitePaths, withKiteRoutes} = require('kite-api/test/helpers/kite');
 const {fakeResponse} = require('kite-connector/test/helpers/http');
-const {jsonPath, walk, describeForTest, featureSetPath, substituteFromContext, buildContext} = require('./json/utils');
+const {jsonPath, walk, describeForTest, featureSetPath, substituteFromContext, buildContext, inLiveEnvironment} = require('./json/utils');
 const NodeClient = require('kite-connector/lib/clients/node');
-const BrowserClient = require('kite-connector/lib/clients/browser');
+// const BrowserClient = require('kite-connector/lib/clients/browser');
 
 const ACTIONS = {};
 const EXPECTATIONS = {};
@@ -92,11 +92,13 @@ function buildTest(data, file) {
   describeForTest(data, `${data.description} ('${file}')`, () => {
     withKite(kiteSetup(data.setup.kited), () => {
       beforeEach(() => {
-        KiteConnect.client = new BrowserClient('localhost', '56624');
-        waitsForPromise(() => KiteConnect.request({
-          path: '/testapi/request-history/reset',
-          method: 'POST',
-        }));
+        if (inLiveEnvironment()) {
+          KiteConnect.client = new NodeClient('localhost', '56624');
+          waitsForPromise(() => KiteConnect.request({
+            path: '/testapi/request-history/reset',
+            method: 'POST',
+          }));
+        }
 
         runs(() => {
           spyOn(KiteAPI, 'request').andCallThrough();
@@ -124,31 +126,31 @@ function buildTest(data, file) {
           }
         }, () => {})();
       };
-      // if (/reachable|authenticated/.test(data.setup.kited)) {
-      //   withKitePaths(pathsSetup(data.setup), undefined, () => {
-      //     if (data.setup.routes) {
-      //       withKiteRoutes(data.setup.routes.map(r => {
-      //         const reg = new RegExp(substituteFromContext(r.match, buildContext()));
-      //
-      //         return [
-      //           o => reg.test(o.path),
-      //           o => {
-      //             if (r.response.body) {
-      //               const body = require(jsonPath(r.response.body));
-      //               return fakeResponse(r.response.status, JSON.stringify(body));
-      //             } else {
-      //               return fakeResponse(r.response.status);
-      //             }
-      //           },
-      //         ];
-      //
-      //       }));
-      //     }
-      //     block();
-      //   });
-      // } else {
-      block();
-      // }
+      if (!inLiveEnvironment() && /reachable|authenticated/.test(data.setup.kited)) {
+        withKitePaths(pathsSetup(data.setup), undefined, () => {
+          if (data.setup.routes) {
+            withKiteRoutes(data.setup.routes.map(r => {
+              const reg = new RegExp(substituteFromContext(r.match, buildContext()));
+
+              return [
+                o => reg.test(o.path),
+                o => {
+                  if (r.response.body) {
+                    const body = require(jsonPath(r.response.body));
+                    return fakeResponse(r.response.status, JSON.stringify(body));
+                  } else {
+                    return fakeResponse(r.response.status);
+                  }
+                },
+              ];
+
+            }));
+          }
+          block();
+        });
+      } else {
+        block();
+      }
     });
   });
 }

--- a/spec/json/actions/open.js
+++ b/spec/json/actions/open.js
@@ -18,11 +18,11 @@ module.exports = (action, testData) => {
     if (testData.setup.kited === 'authenticated') {
       waitsFor('kite editor', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.kiteEditorForEditor(editor), 50);
+      Kite.kiteEditorForEditor(editor), 500);
 
       waitsFor('kite whitelist state', () =>
       !/\.py$/.test(action.properties.file) ||
-      Kite.whitelistedEditorIDs[editor.id] != undefined, 50);
+      Kite.whitelistedEditorIDs[editor.id] != undefined, 500);
     }
   });
 };

--- a/spec/json/expectations/request.js
+++ b/spec/json/expectations/request.js
@@ -28,14 +28,14 @@ const getDesc = (expectation, not) => () => {
   }  else {
     if (closeMatches && closeMatches.length > 0) {
       base.push('\nbut some calls were close');
-      closeMatches.forEach(({path, method, payload}) => {
-        base.push(`\n - ${method} ${path} ${payload}`);
+      closeMatches.forEach(({path, method, body}) => {
+        base.push(`\n - ${method} ${path} ${body}`);
       });
     } else {
       base.push('\nbut no calls were anywhere close');
       KiteAPI.request.calls.forEach(call => {
-        const [{method, path}, payload] = call.args;
-        base.push(`\n - ${method || 'GET'} ${path} ${payload || ''}`);
+        const [{method, path}, body] = call.args;
+        base.push(`\n - ${method || 'GET'} ${path} ${body || ''}`);
       });
     }
   }
@@ -43,8 +43,14 @@ const getDesc = (expectation, not) => () => {
   return base.join(' ');
 };
 
-const mostRecentCallMatching = (exPath, exMethod, exPayload, context = {}, env) => {
-  const calls = KiteAPI.request.calls;
+const mostRecentCallMatching = (data, exPath, exMethod, exPayload, context = {}, env) => {
+  const calls = data || KiteAPI.request.calls.map(c => {
+    return {
+      path: c.args[0].path,
+      method: c.args[0].method,
+      body: c.args[1],
+    };
+  });
   closeMatches = [];
   exactMatch = null;
   let matched = false;
@@ -58,22 +64,20 @@ const mostRecentCallMatching = (exPath, exMethod, exPayload, context = {}, env) 
   if (calls.length === 0) { return false; }
 
   return calls.reverse().reduce((b, c, i, a) => {
-    let [{path, method}, payload] = c.args;
+    let {path, method, body} = c;
     method = method || 'GET';
 
     // b is false here only if we found a call that partially matches
-    // the expected parameters, eg. same endpoint but different method/payload
+    // the expected parameters, eg. same endpoint but different method/body
     // so that mean the most recent call to the expected endpoint is not the one
     // we were looking for, and the assertion must fail immediately
     if (!b || matched) { return b; }
 
-    // console.log(path, method, payload);
-
     if (path === exPath) {
       if (method === exMethod) {
-        closeMatches.push({path, method, payload});
-        if (!exPayload || env.equals_(JSON.parse(payload), exPayload)) {
-          exactMatch = {path, method, payload};
+        closeMatches.push({path, method, body});
+        if (!exPayload || env.equals_(JSON.parse(body), exPayload)) {
+          exactMatch = {path, method, body};
           matched = true;
           return true;
         } else {
@@ -97,13 +101,19 @@ const mostRecentCallMatching = (exPath, exMethod, exPayload, context = {}, env) 
 module.exports = (expectation, not) => {
   beforeEach(function() {
     const promise = waitsFor(() => {
-      return mostRecentCallMatching(
-        expectation.properties.path,
-        expectation.properties.method,
-        expectation.properties.body,
-        buildContext(),
-        this.env);
-    }, 300);
+      return KiteAPI.requestJSON({path: '/testapi/request-history'})
+      .then((data) => {
+        if (!mostRecentCallMatching(
+              data,
+              expectation.properties.path,
+              expectation.properties.method,
+              expectation.properties.body,
+              buildContext(),
+              this.env)) {
+          throw new Error('fail');
+        }
+      });
+    }, 1500, 50);
 
     if (not) {
       waitsForPromise({label: getDesc(expectation, not), shouldReject: true}, () => promise);

--- a/spec/json/utils.js
+++ b/spec/json/utils.js
@@ -6,6 +6,10 @@ const path = require('path');
 const base = path.resolve(__dirname, '..');
 const testBase = path.join(base, '..', 'node_modules', 'editors-json-tests');
 
+function inLiveEnvironment() {
+  return process.env.LIVE_ENVIRONMENT != undefined;
+}
+
 function jsonPath(...p) {
   return path.join(testBase, ...p);
 }
@@ -276,15 +280,16 @@ if (!NotificationsMock.initialized) {
 }
 
 module.exports = {
-  jsonPath,
-  walk,
-  loadPayload,
-  substituteFromContext,
   buildContext,
-  itForExpectation,
   describeForTest,
+  featureSetPath,
+  inLiveEnvironment,
+  itForExpectation,
+  jsonPath,
+  loadPayload,
+  NotificationsMock,
+  substituteFromContext,
   waitsFor,
   waitsForPromise,
-  NotificationsMock,
-  featureSetPath,
+  walk,
 };

--- a/spec/json/utils.js
+++ b/spec/json/utils.js
@@ -64,10 +64,19 @@ function waitsFor(m, f, t, i) {
 
   return new Promise((resolve, reject) => {
     const interval = setInterval(() => {
-      if (f()) {
-        clearTimeout(timeout);
-        clearInterval(interval);
-        resolve();
+      const res = f();
+      if (res) {
+        if (res.then) {
+          res.then(() => {
+            clearTimeout(timeout);
+            clearInterval(interval);
+            resolve();
+          }, (err) => {});
+        } else {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve();
+        }
       }
     }, intervalTime);
 

--- a/spec/signature-plus-completions-spec.js
+++ b/spec/signature-plus-completions-spec.js
@@ -8,7 +8,7 @@ const {fakeResponse} = require('kite-api/test/helpers/http');
 const projectPath = path.join(__dirname, 'fixtures');
 let Kite;
 
-describe('signature + completion', () => {
+xdescribe('signature + completion', () => {
   let workspaceElement, jasmineContent, editor, editorView, completionList;
 
   beforeEach(() => {

--- a/spec/signature-plus-completions-spec.js
+++ b/spec/signature-plus-completions-spec.js
@@ -4,11 +4,12 @@ const fs = require('fs');
 const path = require('path');
 const {withKite, withKiteRoutes, withKitePaths} = require('kite-api/test/helpers/kite');
 const {fakeResponse} = require('kite-api/test/helpers/http');
+const completions = require('../lib/completions');
 
 const projectPath = path.join(__dirname, 'fixtures');
 let Kite;
 
-xdescribe('signature + completion', () => {
+describe('signature + completion', () => {
   let workspaceElement, jasmineContent, editor, editorView, completionList;
 
   beforeEach(() => {
@@ -22,6 +23,8 @@ xdescribe('signature + completion', () => {
     jasmineContent.appendChild(workspaceElement);
 
     waitsForPromise('package activation', () => atom.packages.activatePackage('language-python'));
+    delete completions.signaturePanel;
+    delete completions.suggestionListElement;
   });
 
   withKite({logged: true}, () => {


### PR DESCRIPTION
Includes changing the `request` and `request_count` expectation to hit the request history endpoint and enabling the live testing using a `LIVE_ENVIRONMENT` variable.

I had to deactivate an unrelated test to get the build pass. I'll look into this later.