### PR TITLE
Remove suggestions limit along with signature

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -112,11 +112,7 @@ const KiteProvider = {
     return DataLoader.getSignaturesAtPosition(editor, position || editor.getCursorBufferPosition())
     .then(data => {
       if (data) {
-        const listElement = this.getSuggestionsListElement( );
-
-        listElement.maxVisibleSuggestions = compact
-          ? atom.config.get('autocomplete-plus.maxVisibleSuggestions')
-          : atom.config.get('kite.maxVisibleSuggestionsAlongSignature');
+        const listElement = this.getSuggestionsListElement();
 
         const isNewSigPanel = this.signaturePanel == null;
         this.signaturePanel = this.signaturePanel || new KiteSignature();

--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -21,16 +21,11 @@ class KiteSignature extends HTMLElement {
   detachedCallback() {
     this.subscriptions && this.subscriptions.dispose();
     if (this.parentNode) {
-      this.listElement.maxVisibleSuggestions = atom.config.get('autocomplete-plus.maxVisibleSuggestions');
       this.parentNode.removeChild(this);
     }
   }
 
   attachedCallback() {
-    this.listElement.maxVisibleSuggestions = this.compact
-      ? atom.config.get('autocomplete-plus.maxVisibleSuggestions')
-      : atom.config.get('kite.maxVisibleSuggestionsAlongSignature');
-
     requestAnimationFrame(() => this.checkWidth());
   }
 

--- a/package.json
+++ b/package.json
@@ -49,11 +49,6 @@
       "title": "Enable hover info",
       "description": "Show hover information when placing the mouse over a programming expression"
     },
-    "maxVisibleSuggestionsAlongSignature": {
-      "type": "integer",
-      "default": 3,
-      "title": "Max visible suggestions along signature"
-    },
     "hideDocumentationWhenSignatureIsAvailable": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
Remove the setting and the logic in the signature panel that was changing the suggestion list value at runtime when the signature was visible.