### PR TITLE
Don't expect a parent node to reset the suggestions list limit

### DIFF
--- a/lib/elements/kite-signature.js
+++ b/lib/elements/kite-signature.js
@@ -20,8 +20,8 @@ class KiteSignature extends HTMLElement {
 
   detachedCallback() {
     this.subscriptions && this.subscriptions.dispose();
+    this.listElement.maxVisibleSuggestions = atom.config.get('autocomplete-plus.maxVisibleSuggestions');
     if (this.parentNode) {
-      this.listElement.maxVisibleSuggestions = atom.config.get('autocomplete-plus.maxVisibleSuggestions');
       this.parentNode.removeChild(this);
     }
   }


### PR DESCRIPTION
This solves the issue of not resetting the maximum visible items in completions once the signature is no longer visible