### PR TITLE
fixes #448; adds helpful dev script command

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -518,6 +518,10 @@ const Kite = module.exports = {
             safeShowOrHide.call(manager, options);
           }
         };
+        // this line below is needed to update the manager's callback reference for onDidChangeText from the
+        // original showOrHideSuggestionListForBufferChanges, since that was bound
+        // see https://github.com/atom/autocomplete-plus/blob/master/lib/autocomplete-manager.js#L106
+        manager.buffer && manager.buffer.onDidChangeText(manager.showOrHideSuggestionListForBufferChanges);
 
         manager.displaySuggestions = (suggestions, options) => {
           if (element.querySelector('kite-signature')) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "lint:fix": "eslint --fix ."
+    "lint:fix": "eslint --fix .",
+    "clean-dev-install": "apm unlink && rm -rf node_modules && rm package-lock.json && apm install && apm link"
   },
   "configSchema": {
     "showWelcomeNotificationOnStartup": {


### PR DESCRIPTION
The [original](https://github.com/kiteco/atom-plugin/pull/449/files#diff-8cdc4f637889aec27a6a8f6913f34c93R832) fix implementation was lacking in a tricky way. The method implemented there was sufficient to patch up the problem, but due to the binding of `autocomplete-plus`'s source implementation [here](https://github.com/atom/autocomplete-plus/blob/master/lib/autocomplete-manager.js#L106), the use of the patched method on text changes wouldn't actually go into effect until `updateCurrentEditor` was called. This was tricky to catch in development, because the conditions it required to reproduce required that, among perhaps other conditions, the editor not be changed or refreshed.

To test, you can use the new script I defined in `package.json`. IE run `npm run clean-dev-install` to set up a dev env where this case can be tested

Once this is merged, I'll write up and submit an issue to `autocomplete-plus` to see if we can get a non-hacky fix for this issue underway

cc @metalogical 