### PR TITLE
Minor fixes

### DIFF
--- a/lib/elements/kite-hover.js
+++ b/lib/elements/kite-hover.js
@@ -36,7 +36,7 @@ class KiteHover extends HTMLElement {
         data.report.definition.filename &&
         data.report.definition.filename.trim() !== '') {
         actions.push(`<a
-        href="${internalGotoURL(data.report.definition)}">Def</a>`);
+        href="${internalGotoURL(data.report.definition)}">Def<span class="kite-link-icon">&#167;</span></a>`);
       }
 
       actions.push(`<a href="${internalExpandURL(symbol.id)}">Docs<span class="kite-link-icon">&#8663;</span></a>`);

--- a/lib/elements/kite-hover.js
+++ b/lib/elements/kite-hover.js
@@ -35,8 +35,9 @@ class KiteHover extends HTMLElement {
       if (data.report.definition &&
         data.report.definition.filename &&
         data.report.definition.filename.trim() !== '') {
+          //&#167; &#10550; &#8619;
         actions.push(`<a
-        href="${internalGotoURL(data.report.definition)}">Def<span class="kite-link-icon">&#167;</span></a>`);
+        href="${internalGotoURL(data.report.definition)}">Def<span class="kite-link-icon">&#8619;</span></a>`);
       }
 
       actions.push(`<a href="${internalExpandURL(symbol.id)}">Docs<span class="kite-link-icon">&#8663;</span></a>`);

--- a/lib/elements/kite-hover.js
+++ b/lib/elements/kite-hover.js
@@ -35,7 +35,6 @@ class KiteHover extends HTMLElement {
       if (data.report.definition &&
         data.report.definition.filename &&
         data.report.definition.filename.trim() !== '') {
-          //&#167; &#10550; &#8619;
         actions.push(`<a
         href="${internalGotoURL(data.report.definition)}">Def<span class="kite-link-icon">&#8619;</span></a>`);
       }

--- a/lib/kite-editor.js
+++ b/lib/kite-editor.js
@@ -55,12 +55,13 @@ class KiteEditor {
       if (atom.config.get('kite.enableHoverUI')) {
         if (!OverlayManager) { OverlayManager = require('./overlay-manager'); }
         OverlayManager.showHoverAtPositionWithDelay(editor, position);
+        OverlayManager.setWordHoverActive(true);
       }
     }));
     subs.add(this.hoverGesture.onDidDeactivate(() => {
       if (atom.config.get('kite.enableHoverUI')) {
         if (!OverlayManager) { OverlayManager = require('./overlay-manager'); }
-        OverlayManager.dismissWithDelay();
+        OverlayManager.setWordHoverActive(false);
       }
     }));
 
@@ -68,7 +69,7 @@ class KiteEditor {
       if (!Kite) { Kite = require('./kite'); }
       if (atom.config.get('kite.enableHoverUI')) {
         if (!OverlayManager) { OverlayManager = require('./overlay-manager'); }
-        OverlayManager.dismissWithDelay();
+        OverlayManager.setWordHoverActive(false);
       }
     }));
   }

--- a/lib/overlay-manager.js
+++ b/lib/overlay-manager.js
@@ -1,18 +1,21 @@
 'use strict';
 
-const {Emitter} = require('atom');
+const {Emitter, CompositeDisposable} = require('atom');
 const VirtualCursor = require('./virtual-cursor');
 const KiteHover = require('./elements/kite-hover');
 const DataLoader = require('./data-loader');
 const metrics = require('./metrics');
+const {DisposableEvent} = require('./utils');
 
 module.exports = {
   emitter: new Emitter(),
   queue: Promise.resolve(),
   hoverDefault: {
     show: 750,
-    hide: 100,
+    hide: 500,
   },
+  isCursorInHover: false,
+  isWordHoverActive: false,
 
   reset() {
     this.queue = Promise.resolve();
@@ -27,6 +30,14 @@ module.exports = {
 
     return this.queue;
   },
+
+  setWordHoverActive(isActive) {
+    this.isWordHoverActive = isActive;
+    if (!this.isWordHoverActive && !this.isCursorInHover) {
+      this.dismissWithDelay();
+    }
+  },
+
 
   onDidShowExpand(listener) {
     return this.emitter.on('did-show-expand', listener);
@@ -43,11 +54,14 @@ module.exports = {
   dismiss(from) {
     this.marker && this.marker.destroy();
     this.decoration && this.decoration.destroy();
+    this.hoverSubscriptions && this.hoverSubscriptions.dispose();
     delete this.marker;
     delete this.decoration;
     delete this.lastHoverRange;
     delete this.lastExpandRange;
     delete this.expandDisplayed;
+    this.isCursorInHover = false;
+    this.isWordHoverActive = false;
 
     this.emitter.emit('did-dismiss');
   },
@@ -68,7 +82,10 @@ module.exports = {
   },
 
   abortDismissWithDelay() {
-    if (this.dismissTimeout) { clearTimeout(this.dismissTimeout); }
+    if (this.dismissTimeout) {
+      clearTimeout(this.dismissTimeout);
+      delete this.dismissTimeout; 
+    }
   },
 
   showHoverAtPositionWithDelay(editor, position) {
@@ -105,11 +122,23 @@ module.exports = {
       if (range.isEmpty()) { return null; }
 
       this.lastHoverRange = range;
-
       return DataLoader.getHoverDataAtPosition(editor, position).then(data => {
         if (data.symbol && data.symbol.length) {
           metrics.featureFulfilled && metrics.featureFulfilled('hover');
           const hover = new KiteHover();
+
+          this.hoverSubscriptions = new CompositeDisposable();
+          this.hoverSubscriptions.add(new DisposableEvent(hover, 'mouseover', (e) => {
+            this.isCursorInHover = true;
+            this.abortDismissWithDelay();
+          }));
+          this.hoverSubscriptions.add(new DisposableEvent(hover, 'mouseout', (e) => {
+            this.isCursorInHover = false;
+            if (!this.isCursorInHover && !this.isWordHoverActive) {
+              this.dismissWithDelay();
+            }
+          }));
+
           hover.setData(data, editor, position);
 
           this.marker = editor.markBufferRange(range, {

--- a/styles/kite-links.less
+++ b/styles/kite-links.less
@@ -26,12 +26,8 @@ kite-links {
     margin: -1em 0;
 
     .kite-link-icon {
-      color: @text-color-highlight !important;
+      color: @text-color !important;
       padding-left: 2px;
-    }
-
-    .kite-link-icon:hover {
-      color: @text-color-highlight !important;
     }
   }
   a:hover {


### PR DESCRIPTION
Does two things around hover in Atom
1. Adds an icon to `def` in the Hover (I also toned down icon color intensity). I considered ultimately three icons (and would like further input):
   a. unicode &#8619;
      <img width="239" alt="Screen Shot 2019-03-28 at 9 32 58 AM" src="https://user-images.githubusercontent.com/6146901/55175701-0c233680-513d-11e9-850b-051455475d69.png">
      My personal favorite - I think the loop in conjunction with the arrow effectively communicates that one is "traveling" within the editor screen to get to something connected with the `def` of the hovered token

   b. unicode &#10550; 
       <img width="225" alt="Screen Shot 2019-03-28 at 9 34 23 AM" src="https://user-images.githubusercontent.com/6146901/55176025-966b9a80-513d-11e9-95c2-e5ebba144888.png">
      A little more "standard" looking than the looping arrow

   c. unicode &#167;    
      <img width="244" alt="Screen Shot 2019-03-28 at 9 33 44 AM" src="https://user-images.githubusercontent.com/6146901/55176154-d599eb80-513d-11e9-9ae4-b44346900abc.png">
      the [symbol](https://en.wikipedia.org/wiki/Section_sign) has decently close established semantics to what our `def` means. But established semantics does always imply common user interpretation

2. Does a bit of reconfiguring to the mechanics of showing/hiding a hover. I increased the dismissal delay, but also made dismissal conditional on both the hovered token _and_ the hover element no longer having the cursor in them. The previous implementation only paid attention to the hovered token, which led to frustrating behavior. 

 