### PR TITLE
Fix signatures not appearing after backspacing

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -580,7 +580,6 @@ const Kite = module.exports = {
             if (desc) {
               if (suggestions.length === 0) {
                 desc.style.display = 'none';
-                return;
               } else {
                 desc.style.display = '';
               }


### PR DESCRIPTION
From QA: (May also fix https://github.com/kiteco/kiteco/issues/8056)

> type json.dumps()
> remove ()
> type (
> it will autofill "json.dumps()" but won't give info

This was something I erroneously added while implementing snippets.