### PR TITLE
Snippets tab fixes

### DIFF
--- a/lib/kite-data-utils.js
+++ b/lib/kite-data-utils.js
@@ -287,6 +287,7 @@ const appendCompletionsFooter = (completion, descriptionHTML) => {
 };
 
 const parseSnippetCompletion = (editor, c, displayPrefix) => {
+  const buffer = editor.getBuffer();
   const completion = {
     text: c.snippet.text,
     displayText: displayPrefix + c.display,
@@ -294,8 +295,8 @@ const parseSnippetCompletion = (editor, c, displayPrefix) => {
   };
   if (c.replace) {
     completion.replacementRange = {
-      begin: editor.getBuffer().positionForCharacterIndex(c.replace.begin),
-      end: editor.getBuffer().positionForCharacterIndex(c.replace.end),
+      begin: buffer.positionForCharacterIndex(c.replace.begin),
+      end: buffer.positionForCharacterIndex(c.replace.end),
     };
   }
   if (c.snippet.placeholders.length > 0) {
@@ -309,6 +310,18 @@ const parseSnippetCompletion = (editor, c, displayPrefix) => {
       + '${' + (i + 1).toString() + ':' + snippetStr.slice(placeholder.begin, placeholder.end) 
       + '}' + snippetStr.slice(placeholder.end);
       offset += 5;
+    }
+    if (snippetStr) {
+      // snippetStr does not contain closing parenthesis when cursor is inside function call.
+      // So, add closing parenthesis, terminating tab stop, and adjust replacement range end.
+      if (snippetStr[snippetStr.length - 1] !== ')') {
+        snippetStr += ')$0';
+        const newEnd = buffer.characterIndexForPosition(completion.replacementRange.end) + 1;
+        completion.replacementRange.end = buffer.positionForCharacterIndex(newEnd);
+      // snippetStr contains closing parenthesis, append terminating tab stop directly.
+      } else {
+        snippetStr += '$0';
+      }
     }
     completion.snippet = snippetStr;
   }

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -499,12 +499,34 @@ const Kite = module.exports = {
         manager.confirm = (suggestion) => {
           confirmed = true;
           requestAnimationFrame(() => confirmed = false);
-          return safeConfirm.call(manager, suggestion);
+          if (atom.config.get('kite.enableSnippets')) {
+            // Patch ACP's confirm so that it doesn't clear selections upon confirmation.
+            // Fixes undo not re-highlighting placeholders in a snippet
+            // when a suggestion is inserted directly into the buffer.
+            // Based on https://github.com/atom/autocomplete-plus/blob/master/lib/autocomplete-manager.js#L538
+            if ((manager.editor === null) || (suggestion === null) || !!manager.disposed) { return; }
+            const apiVersion = manager.providerManager.apiVersionForProvider(suggestion.provider);
+            const triggerPosition = manager.editor.getLastCursor().getBufferPosition();
+            manager.hideSuggestionList();
+            manager.replaceTextWithMatch(suggestion);
+            if (apiVersion > 1) {
+              if (suggestion.provider && suggestion.provider.onDidInsertSuggestion) {
+                suggestion.provider.onDidInsertSuggestion({editor: manager.editor, suggestion, triggerPosition});
+              }
+            } else {
+              if (suggestion.onDidConfirm) {
+                suggestion.onDidConfirm();
+              }
+            }
+          } else {
+            safeConfirm.call(manager, suggestion);
+          }
         };
 
         manager.replaceTextWithMatch = (suggestion) => {
           if (atom.config.get('kite.enableSnippets')) {
             // Tweak behavior of ACP text replacement
+            // Based on https://github.com/atom/autocomplete-plus/blob/master/lib/autocomplete-manager.js#L613
             const editor = manager.editor;
             if (!editor) { return; }
             const cursor = editor.getLastCursor();

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -439,6 +439,25 @@ const Kite = module.exports = {
           const snippets = snippetsPkg.mainModule;
           const safeGoToNextTabStop = snippets && snippets.goToNextTabStop;
           const safeGoToPreviousTabStop = snippets && snippets.goToPreviousTabStop;
+
+          this.subscriptions.add(new Disposable(() => {
+            snippets.goToNextTabStop = safeGoToNextTabStop;
+            snippets.goToPreviousTabStop = safeGoToPreviousTabStop;
+          }));
+
+          this.subscriptions.add(
+            atom.commands.add('atom-text-editor[data-grammar="source python"]', {
+              'autocomplete-plus:confirm': event => {
+                // In the event that the sig panel is active,
+                // but the suggestion list is not, we want to have tab and enter
+                // defer to the next layer of events, i.e. next tab stop
+                // and line break respectively. Without this, tab will just close
+                // the sig panel.
+                if (!list.items) {
+                  event.abortKeyBinding();
+                }
+              },
+            }));
           
           snippets.goToNextTabStop = (editor) => {
             manager.findSuggestions(false);


### PR DESCRIPTION
- Adds a tab stop at the end of a snippet string. I.e. at `foobar(|)`, hitting tab will move the cursor to `foobar()|`
- Fixes issue where a user has to tab multiple times to move to the next snippet tab stop.