### PR TITLE
Toggle ACP excludes value to filter out duplicate suggestions

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -13,7 +13,7 @@ const KiteProvider = {
   ].join(', '),
   inclusionPriority: 5,
   suggestionPriority: 5,
-  excludeLowerPriority: false,
+  excludeLowerPriority: true,
   
   // called to handle attribute completions
   getSuggestions(params) {


### PR DESCRIPTION
As per https://github.com/atom/autocomplete-plus/wiki/Provider-API#defining-a-provider, setting `excludeLowerPriority` to true will exclude suggestions from lower priority providers.