### PR TITLE
Fix for suggestions not appearing after a tab stop

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -459,14 +459,28 @@ const Kite = module.exports = {
               },
             }));
           
+          // Fetch suggestion after the next tab stop is visited.
           snippets.goToNextTabStop = (editor) => {
+            let nextTabStopVisited = false;
+            for (const expansion of snippets.getExpansions(editor)) {
+              if (expansion && expansion.goToNextTabStop()) {
+                nextTabStopVisited = true;
+              }
+            }
             manager.findSuggestions(false);
-            return safeGoToNextTabStop.call(snippets, editor);
+            return nextTabStopVisited;
           };
-  
+          
+          // Fetch suggestion after visting the previous tab stop.
           snippets.goToPreviousTabStop = (editor) => {
+            let previousTabStopVisited = false;
+            for (const expansion of snippets.getExpansions(editor)) {
+              if (expansion && expansion.goToPreviousTabStop()) {
+                previousTabStopVisited = true;
+              }
+            }
             manager.findSuggestions(false);
-            return safeGoToPreviousTabStop.call(snippets, editor);
+            return previousTabStopVisited;
           };
         });
       }


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/8115

Previously, we get suggestions then go to the next/previous tab stop, causing a race condition in which snippets prevents autocomplete-plus from displaying completions.

To address this, I took the code from the original snippets [codebase](https://github.com/atom/snippets/blob/master/lib/snippets.js#L536) and overrode it s.t. we fetch suggestions after snippets moves to a different tab stop.