### PR TITLE
Fix Autocomplete For Non-Kite Suggestions

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -538,7 +538,7 @@ const Kite = module.exports = {
         };
 
         manager.replaceTextWithMatch = (suggestion) => {
-          if (atom.config.get('kite.enableSnippets')) {
+          if (atom.config.get('kite.enableSnippets') && suggestion.className === 'kite-completion') {
             // Tweak behavior of ACP text replacement
             // Based on https://github.com/atom/autocomplete-plus/blob/master/lib/autocomplete-manager.js#L613
             const editor = manager.editor;


### PR DESCRIPTION
Tighten condition for using custom text insertion logic so that in addition to snippets being enabled, the suggestion must have class name 'kite-completion'.