### PR TITLE
Fix tabbing behavior within a nested snippet

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -568,10 +568,11 @@ const Kite = (module.exports = {
           // Fetch suggestion after the next tab stop is visited.
           snippets.goToNextTabStop = editor => {
             let nextTabStopVisited = false;
-            for (const expansion of snippets.getExpansions(editor)) {
-              if (expansion && expansion.goToNextTabStop()) {
-                nextTabStopVisited = true;
-              }
+            const expansions = snippets.getExpansions(editor);
+            // Nested snippets are added to the end of the expansions array, so process the last item
+            const expansion = expansions[expansions.length - 1];
+            if (expansion && expansion.goToNextTabStop()) {
+              nextTabStopVisited = true;
             }
             manager.requestNewSuggestions();
             return nextTabStopVisited;
@@ -580,10 +581,11 @@ const Kite = (module.exports = {
           // Fetch suggestion after visting the previous tab stop.
           snippets.goToPreviousTabStop = editor => {
             let previousTabStopVisited = false;
-            for (const expansion of snippets.getExpansions(editor)) {
-              if (expansion && expansion.goToPreviousTabStop()) {
-                previousTabStopVisited = true;
-              }
+            const expansions = snippets.getExpansions(editor);
+            // Nested snippets are added to the end of the expansions array, so process the last item
+            const expansion = expansions[expansions.length - 1];
+            if (expansion && expansion.goToPreviousTabStop()) {
+              previousTabStopVisited = true;
             }
             manager.requestNewSuggestions();
             return previousTabStopVisited;


### PR DESCRIPTION
Fixes https://github.com/kiteco/kiteco/issues/8713

In the case where there's one snippet, `expansions` contains one item. If there are nested snippets, the most recently added snippet is the last item in the list.

However, being able to tab out of a nested snippet into the original snippet is not in scope for this PR, since the Atom Snippets package itself doesn't support that behavior.