### PR TITLE
don't force scroll past end

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -207,10 +207,6 @@ const Kite = (module.exports = {
       });
     }
 
-    // we aggressively turn on the scrollPastEnd setting in order for KSG to function best
-    // should we gate this in a notification similar to the tree-sitter one?
-    atom.config.set('editor.scrollPastEnd', true);
-
     this.subscriptions.add(
       atom.config.observe('kite.loggingLevel', level => {
         Logger.LEVEL = Logger.LEVELS[level.toUpperCase()];


### PR DESCRIPTION
fixes #631 

It doesn't appear that the StackOverflow search experience is significantly degraded without "scroll past end" enabled, based on my testing.

The alternative is to suggest that the user disable it via a dismissable notification.