### PR TITLE
Atom Onboarding with Command Palette

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -271,7 +271,9 @@ const Kite = (module.exports = {
     this.subscriptions.add(
       atom.commands.add('atom-workspace', {
         'kite:search-stack-overflow': () => this.toggleKSG(),
-        'kite:tutorial': () => this.openKiteTutorial(true),
+        'kite:python-tutorial': () => this.openKiteTutorial(true, 'python'),
+        'kite:javascript-tutorial': () => this.openKiteTutorial(true, 'javascript'),
+        'kite:go-tutorial': () => this.openKiteTutorial(true, 'go'),
         'kite:engine-settings': () => this.openSettings(),
         'kite:open-copilot': () => this.openCopilot(),
         'kite:package-settings': () =>
@@ -469,9 +471,9 @@ const Kite = (module.exports = {
     atom.applicationDelegate.openExternal(url);
   },
 
-  openKiteTutorial(fromCommand) {
+  openKiteTutorial(fromCommand, language) {
     if (fromCommand) {
-      KiteAPI.getOnboardingFilePath('atom')
+      KiteAPI.getOnboardingFilePath('atom', language)
         .then(path => {
           atom.workspace.open(path);
         })


### PR DESCRIPTION
Addresses Atom for kiteco/kiteco#10456 for the updated spec.

### What was done
Essentially leveraged the second argument in `KiteAPI.getOnboardingFilePath` to pull language specific tutorial files. They don't yet exist so this change would at the moment create a warning notification. ~Should test and merge after those files get added to the endpoint.~ Should merge for release at JS public launch.

### QA
Check that:

1. Opening Atom with `kite.showWelcomeNotificationOnStartup: true` in atom's `config.cson` and `"has_done_onboarding": "false"` in `~/.kite/settings.json` attempts to open the Python onboarding file. (no regression)
2. Commands for `Kite: Go Tutorial` and `Kite: Javascript Tutorial` are present in the command palette. (Note that these will fail to pull an onboarding file from kited at the moment as those files do not exist).