### PR TITLE
Remove completion request on placeholder selection

### DIFF
--- a/lib/kite.js
+++ b/lib/kite.js
@@ -545,14 +545,10 @@ const Kite = (module.exports = {
       if (atom.config.get('kite.enableSnippets')) {
         atom.packages.activatePackage('snippets').then(snippetsPkg => {
           const snippets = snippetsPkg.mainModule;
-          const safeGoToNextTabStop = snippets && snippets.goToNextTabStop;
-          const safeGoToPreviousTabStop = snippets && snippets.goToPreviousTabStop;
           const safeInsertSnippet = manager && manager.snippetsManager && manager.snippetsManager.insertSnippet;
 
           this.subscriptions.add(
             new Disposable(() => {
-              snippets.goToNextTabStop = safeGoToNextTabStop;
-              snippets.goToPreviousTabStop = safeGoToPreviousTabStop;
               manager.snippetsManager.insertSnippet = safeInsertSnippet;
             })
           );
@@ -586,32 +582,6 @@ const Kite = (module.exports = {
               snippet = new Snippet({ name: '__anonymous', prefix: '', bodyTree, bodyText: snippet });
             }
             return new SnippetExpansion(snippet, editor, cursor, snippets, shouldNotIndent);
-          };
-
-          // Fetch suggestion after the next tab stop is visited.
-          snippets.goToNextTabStop = editor => {
-            let nextTabStopVisited = false;
-            const expansions = snippets.getExpansions(editor);
-            // Nested snippets are added to the end of the expansions array, so process the last item
-            const expansion = expansions[expansions.length - 1];
-            if (expansion && expansion.goToNextTabStop()) {
-              nextTabStopVisited = true;
-            }
-            manager.requestNewSuggestions();
-            return nextTabStopVisited;
-          };
-
-          // Fetch suggestion after visting the previous tab stop.
-          snippets.goToPreviousTabStop = editor => {
-            let previousTabStopVisited = false;
-            const expansions = snippets.getExpansions(editor);
-            // Nested snippets are added to the end of the expansions array, so process the last item
-            const expansion = expansions[expansions.length - 1];
-            if (expansion && expansion.goToPreviousTabStop()) {
-              previousTabStopVisited = true;
-            }
-            manager.requestNewSuggestions();
-            return previousTabStopVisited;
           };
         });
       }
@@ -789,7 +759,7 @@ const Kite = (module.exports = {
             // Fix case where shouldDisplaySuggestion is ignored when suggestion hiding methods are invoked,
             // unless a snippet is confirmed. This is because cursorMoved is called after snippet confirmation
             // causing shouldDisplaySuggestions to be false when we want it to be true.
-            if (atom.config.get('kite.enableSnippets') && (!manager.shouldDisplaySuggestions && !wasSnippetConfirmed)) {
+            if (!manager.shouldDisplaySuggestions) {
               return;
             }
             if (parseFloat(autocompletePlus.metadata.version) >= 2.36) {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -599,7 +599,6 @@ const Kite = (module.exports = {
 
         let confirmed;
         let wasSnippetConfirmed;
-        let wasSnippetWithPlaceholderConfirmed;
 
         this.subscriptions.add(
           new Disposable(() => {
@@ -616,15 +615,6 @@ const Kite = (module.exports = {
         manager.confirm = suggestion => {
           confirmed = true;
           wasSnippetConfirmed = suggestion.className === 'kite-completion' && typeof suggestion.snippet !== 'undefined';
-          wasSnippetWithPlaceholderConfirmed = function hasPlaceholder(snippet) {
-            if (typeof snippet === 'undefined') {
-              return false;
-            }
-            const CaptureGroupIDX = 1;
-            const placeholderRegex = /{1:(.*?)}/g;
-            const found = placeholderRegex.exec(snippet);
-            return found && found.length > CaptureGroupIDX && found[CaptureGroupIDX] !== '';
-          }(suggestion.snippet);
           requestAnimationFrame(() => (confirmed = false));
           if (atom.config.get('kite.enableSnippets')) {
             // Patch ACP's confirm so that it doesn't clear selections upon confirmation.
@@ -769,10 +759,7 @@ const Kite = (module.exports = {
             // Fix case where shouldDisplaySuggestion is ignored when suggestion hiding methods are invoked,
             // unless a snippet is confirmed. This is because cursorMoved is called after snippet confirmation
             // causing shouldDisplaySuggestions to be false when we want it to be true.
-            if (
-              atom.config.get('kite.enableSnippets') &&
-              (!manager.shouldDisplaySuggestions && wasSnippetWithPlaceholderConfirmed)
-            ) {
+            if (!manager.shouldDisplaySuggestions) {
               return;
             }
             if (parseFloat(autocompletePlus.metadata.version) >= 2.36) {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -599,6 +599,7 @@ const Kite = (module.exports = {
 
         let confirmed;
         let wasSnippetConfirmed;
+        let wasSnippetWithPlaceholderConfirmed;
 
         this.subscriptions.add(
           new Disposable(() => {
@@ -615,6 +616,15 @@ const Kite = (module.exports = {
         manager.confirm = suggestion => {
           confirmed = true;
           wasSnippetConfirmed = suggestion.className === 'kite-completion' && typeof suggestion.snippet !== 'undefined';
+          wasSnippetWithPlaceholderConfirmed = function hasPlaceholder(snippet) {
+            if (typeof snippet === 'undefined') {
+              return false;
+            }
+            const CaptureGroupIDX = 1;
+            const placeholderRegex = /{1:(.*?)}/g;
+            const found = placeholderRegex.exec(snippet);
+            return found && found.length > CaptureGroupIDX && found[CaptureGroupIDX] !== '';
+          }(suggestion.snippet);
           requestAnimationFrame(() => (confirmed = false));
           if (atom.config.get('kite.enableSnippets')) {
             // Patch ACP's confirm so that it doesn't clear selections upon confirmation.
@@ -759,7 +769,10 @@ const Kite = (module.exports = {
             // Fix case where shouldDisplaySuggestion is ignored when suggestion hiding methods are invoked,
             // unless a snippet is confirmed. This is because cursorMoved is called after snippet confirmation
             // causing shouldDisplaySuggestions to be false when we want it to be true.
-            if (!manager.shouldDisplaySuggestions) {
+            if (
+              atom.config.get('kite.enableSnippets') &&
+              (!manager.shouldDisplaySuggestions && wasSnippetWithPlaceholderConfirmed)
+            ) {
               return;
             }
             if (parseFloat(autocompletePlus.metadata.version) >= 2.36) {


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/11202 for Atom

This should apply to all snippets from all providers because we patch autocomplete-plus's snippets manager to insert our own behavior (cc @edzkite is this true based off your understanding?).

The regex is a bit nasty. We could potentially return a flag from kited instead, but thought I'd get this out for discussion to see if we want to address on-select completions in-editor vs kited for Atom first. Unsure if we always return `1` for the first one/whether to rely on that if we think regex is ok for this.

![behavior](https://user-images.githubusercontent.com/18232816/95278050-2ba42080-0804-11eb-819d-f3fb259d0a70.gif)

This will request completions when selecting `len(filter${1:})$0`. Not sure if that's what we want either.