### PR TITLE
Improve the performance of get suggestions list element 

### DIFF
--- a/lib/completions.js
+++ b/lib/completions.js
@@ -5,6 +5,7 @@ const KiteSignature = require('./elements/kite-signature');
 const { delayPromise } = require('./utils');
 let Kite;
 
+let isAutocompletePlusInstalled = null;
 const KiteProvider = {
   selector: '.source, .text',
   disableForSelector: [
@@ -158,7 +159,12 @@ const KiteProvider = {
   },
 
   getSuggestionsListElement() {
-    if (!atom.packages.getAvailablePackageNames().includes('autocomplete-plus')) {
+    // check for autocomplete-plus installation
+    if (isAutocompletePlusInstalled === null) {
+      isAutocompletePlusInstalled = atom.packages.getAvailablePackageNames().includes('autocomplete-plus');
+    }
+    // return if not installed
+    if (isAutocompletePlusInstalled === false) {
       return null;
     }
     if (this.suggestionListElement) { return this.suggestionListElement; }

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -6,6 +6,8 @@ const { delayPromise } = require('./utils');
 let Kite;
 
 let isAutocompletePlusInstalled = null;
+let autocompletePlusPkg = null;
+
 const KiteProvider = {
   selector: '.source, .text',
   disableForSelector: [
@@ -169,14 +171,17 @@ const KiteProvider = {
     }
     if (this.suggestionListElement) { return this.suggestionListElement; }
 
-    const pkg = atom.packages.getActivePackage('autocomplete-plus').mainModule;
-    if (!pkg || !pkg.autocompleteManager || !pkg.autocompleteManager.suggestionList) {
+    // get autocomplete-plus pkg
+    if (autocompletePlusPkg === null) {
+      autocompletePlusPkg = atom.packages.getActivePackage('autocomplete-plus').mainModule;
+    }
+    if (!autocompletePlusPkg || !autocompletePlusPkg.autocompleteManager || !autocompletePlusPkg.autocompleteManager.suggestionList) {
       return null;
     }
-    const list = pkg.autocompleteManager.suggestionList;
+    const list = autocompletePlusPkg.autocompleteManager.suggestionList;
     this.suggestionListElement = list.suggestionListElement
       ? list.suggestionListElement
-      : atom.views.getView(pkg.autocompleteManager.suggestionList);
+      : atom.views.getView(autocompletePlusPkg.autocompleteManager.suggestionList);
 
     if (!this.suggestionListElement.ol) {
       this.suggestionListElement.renderList();

--- a/lib/completions.js
+++ b/lib/completions.js
@@ -161,17 +161,14 @@ const KiteProvider = {
   },
 
   getSuggestionsListElement() {
-    // check for autocomplete-plus installation
     if (isAutocompletePlusInstalled === null) {
       isAutocompletePlusInstalled = atom.packages.getAvailablePackageNames().includes('autocomplete-plus');
     }
-    // return if not installed
     if (isAutocompletePlusInstalled === false) {
       return null;
     }
     if (this.suggestionListElement) { return this.suggestionListElement; }
 
-    // get autocomplete-plus pkg
     if (autocompletePlusPkg === null) {
       autocompletePlusPkg = atom.packages.getActivePackage('autocomplete-plus').mainModule;
     }


### PR DESCRIPTION
This improves the performance of `get suggestions list element` by caching the values related to autocomplete-plus.

### Benchmarks

Previously Kite was calling quite expensive API such as `atom.packages.getAvailablePackageNames` on every single keystroke. This has caused the performance of the text editor to be reduced.
![image](https://user-images.githubusercontent.com/16418197/97098593-728b7600-164c-11eb-845f-3594f3fa6e8f.png)

This PR fixes this issue by caching the result. This 620ms is completely gone now
![image](https://user-images.githubusercontent.com/16418197/97098610-a1a1e780-164c-11eb-9d6b-12927e6cad35.png)
