### PR TITLE
Send Editor Path In Related Code Request

### DIFF
--- a/lib/codenav.js
+++ b/lib/codenav.js
@@ -17,7 +17,7 @@ module.exports = class Codenav {
 
   relatedCodeFromFileWithEditor(textEditor) {
     KiteAPI
-      .requestRelatedCode('atom', textEditor.getPath(), null, null)
+      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), null, null)
       .catch(this.notifications.getRelatedCodeErrHandler(textEditor.getPath(), null));
   }
 
@@ -37,7 +37,7 @@ module.exports = class Codenav {
     });
 
     requireNonEmptyLine
-      .then(() => KiteAPI.requestRelatedCode('atom', textEditor.getPath(), oneBasedLineNo, null))
+      .then(() => KiteAPI.requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null))
       .catch(this.notifications.getRelatedCodeErrHandler(textEditor.getPath(), oneBasedLineNo));
   }
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "element-resize-detector": "^1.1.11",
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
-    "kite-api": "=3.17.0",
+    "kite-api": "=3.18.0",
     "kite-connector": "=3.12.0",
     "kite-installer": "=3.16.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
`atom.packages.getApmPath()` returns the `apm` path of the editor install.