### PR TITLE
Add .pyw to Python extensions.

### DIFF
--- a/lib/editors.js
+++ b/lib/editors.js
@@ -52,6 +52,7 @@ const EXTENSIONS_BY_LANGUAGES = {
   ],
   python: [
     'py',
+    'pyw',
   ],
   ruby: [
     'rb',


### PR DESCRIPTION
Adds support for the `.pyw` Python extension. Required for https://github.com/kiteco/kiteco/pull/12167