### PR TITLE
Related Code Error Handling Improvements

### DIFF
--- a/lib/codenav.js
+++ b/lib/codenav.js
@@ -18,17 +18,15 @@ module.exports = class Codenav {
   }
 
   relatedCodeFromFileWithEditor(textEditor) {
-    KiteAPI
-      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), null, null)
-      .catch(this.notifications.getRelatedCodeErrHandler());
+    return KiteAPI
+      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), null, null);
   }
 
   relatedCodeFromLineWithEditor(textEditor) {
     const zeroBasedLineNo = textEditor.getCursorBufferPosition().row;
     const oneBasedLineNo = zeroBasedLineNo + 1;
-    KiteAPI
-      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null)
-      .catch(this.notifications.getRelatedCodeErrHandler());
+    return KiteAPI
+      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null);
   }
 
   requireEditor() {

--- a/lib/codenav.js
+++ b/lib/codenav.js
@@ -7,18 +7,20 @@ module.exports = class Codenav {
 
   relatedCodeFromFile() {
     this.requireEditor()
-      .then((textEditor) => this.relatedCodeFromFileWithEditor(textEditor));
+      .then((textEditor) => this.relatedCodeFromFileWithEditor(textEditor))
+      .catch(this.notifications.getRelatedCodeErrHandler());
   }
 
   relatedCodeFromLine() {
     this.requireEditor()
-      .then((textEditor) => this.relatedCodeFromLineWithEditor(textEditor));
+      .then((textEditor) => this.relatedCodeFromLineWithEditor(textEditor))
+      .catch(this.notifications.getRelatedCodeErrHandler());
   }
 
   relatedCodeFromFileWithEditor(textEditor) {
     KiteAPI
       .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), null, null)
-      .catch(this.notifications.getRelatedCodeErrHandler(textEditor.getPath(), null));
+      .catch(this.notifications.getRelatedCodeErrHandler());
   }
 
   relatedCodeFromLineWithEditor(textEditor) {
@@ -26,7 +28,7 @@ module.exports = class Codenav {
     const oneBasedLineNo = zeroBasedLineNo + 1;
     KiteAPI
       .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null)
-      .catch(this.notifications.getRelatedCodeErrHandler(textEditor.getPath(), oneBasedLineNo));
+      .catch(this.notifications.getRelatedCodeErrHandler());
   }
 
   requireEditor() {
@@ -35,7 +37,8 @@ module.exports = class Codenav {
       if (!textEditor) {
         return reject({
           data: {
-            responseData: 'ErrNotTextEditor',
+            // NotificationsCenter expects a JSON string.
+            responseData: JSON.stringify({ message: 'Could not get active text editor.' }),
           },
         });
       }

--- a/lib/codenav.js
+++ b/lib/codenav.js
@@ -24,20 +24,8 @@ module.exports = class Codenav {
   relatedCodeFromLineWithEditor(textEditor) {
     const zeroBasedLineNo = textEditor.getCursorBufferPosition().row;
     const oneBasedLineNo = zeroBasedLineNo + 1;
-
-    const requireNonEmptyLine = new Promise((resolve, reject) => {
-      if (textEditor.lineTextForBufferRow(zeroBasedLineNo) === '') {
-        return reject({
-          data: {
-            responseData: 'ErrEmptyLine',
-          },
-        });
-      }
-      return resolve();
-    });
-
-    requireNonEmptyLine
-      .then(() => KiteAPI.requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null))
+    KiteAPI
+      .requestRelatedCode('atom', atom.packages.getApmPath(), textEditor.getPath(), oneBasedLineNo, null)
       .catch(this.notifications.getRelatedCodeErrHandler(textEditor.getPath(), oneBasedLineNo));
   }
 

--- a/lib/notifications-center.js
+++ b/lib/notifications-center.js
@@ -471,31 +471,16 @@ class NotificationsCenter {
     );
   }
 
-  getRelatedCodeErrHandler(filename, lineNo) {
+  getRelatedCodeErrHandler() {
     return (err) => {
       if (!err) {
         return;
       }
+
       const KiteCodeFinderError = 'Kite Code Finder Error';
-      const showDefaultErrMsg = () => this.queue.addWarning(KiteCodeFinderError, {
-        description: 'Oops! Something went wrong with Code Finder. Please try again later.',
-        buttons: [
-          {
-            text: 'OK',
-            onDidClick: dismiss => dismiss && dismiss(),
-          },
-        ],
-      });
-      if (!err.data) {
-        showDefaultErrMsg();
-        return;
-      }
-
-      const { state, responseData } = err.data;
-
-      if (state && state <= KiteAPI.STATES.UNREACHABLE) {
+      const addWarning = (msg) =>
         this.queue.addWarning(KiteCodeFinderError, {
-          description: 'Kite could not be reached. Please check that Kite engine is running.',
+          description: msg,
           buttons: [
             {
               text: 'OK',
@@ -503,79 +488,31 @@ class NotificationsCenter {
             },
           ],
         });
+
+      const defaultErrMsg = 'Oops! Something went wrong with Code Finder. Please try again later.';
+      if (!err.data) {
+        addWarning(defaultErrMsg);
         return;
       }
 
-      if (responseData && typeof responseData === 'string') {
-        switch (responseData.trim()) {
-          case 'ErrPathHasUnsupportedExtension':
-            this.queue.addWarning(KiteCodeFinderError, {
-              description: `Code Finder does not support the \`${path.extname(filename)}\` file extension yet.`,
-              buttons: [
-                {
-                  text: 'OK',
-                  onDidClick: dismiss => dismiss && dismiss(),
-                },
-              ],
-            });
-            return;
-          case 'ErrPathNotInSupportedProject':
-            this.queue.addWarning(KiteCodeFinderError, {
-              description: [
-                `The file ${filename} is not in any Git project.`,
-                'Code finder only works inside Git projects.',
-              ].join(' '),
-              buttons: [
-                {
-                  text: 'OK',
-                  onDidClick: dismiss => dismiss && dismiss(),
-                },
-              ],
-            });
-            return;
-          case 'ErrProjectStillIndexing':
-            this.queue.addWarning(KiteCodeFinderError, {
-              description: [
-                'Kite is not done indexing your project yet.',
-                'Please wait for the status icon to switch to ready before using Code Finder.',
-              ].join(' '),
-              buttons: [
-                {
-                  text: 'OK',
-                  onDidClick: dismiss => dismiss && dismiss(),
-                },
-              ],
-            });
-            return;
-          case 'ErrEmptyLine':
-            this.queue.addWarning(KiteCodeFinderError, {
-              description: [
-                `Line ${lineNo} in file ${filename} is empty.`,
-                'Code finder only works in non-empty lines.',
-              ].join(' '),
-              buttons: [
-                {
-                  text: 'OK',
-                  onDidClick: dismiss => dismiss && dismiss(),
-                },
-              ],
-            });
-            return;
-          case 'ErrNotTextEditor':
-            this.queue.addWarning(KiteCodeFinderError, {
-              description: 'Could not get active text editor.',
-              buttons: [
-                {
-                  text: 'OK',
-                  onDidClick: dismiss => dismiss && dismiss(),
-                },
-              ],
-            });
-            return;
-        }
+      const { state, responseData } = err.data;
+
+      if (state && state <= KiteAPI.STATES.UNREACHABLE) {
+        addWarning('Kite could not be reached. Please check that Kite engine is running.');
+        return;
       }
 
-      showDefaultErrMsg();
+      try {
+        const { message } = JSON.parse(responseData);
+        if (message) {
+          addWarning(message);
+          return;
+        }
+      } catch (e) {
+        console.error(e);
+      }
+
+      addWarning(defaultErrMsg);
     };
   }
 


### PR DESCRIPTION
Atom portion of https://github.com/kiteco/kiteco/issues/12248

In addition to removing empty line checks:
- Cleaned up `getRelatedCodeErrHandler`
- Fix error handling when there's no active text editor