### PR TITLE
Codenav line decoration

### DIFF
--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -1,0 +1,95 @@
+const KiteAPI = require('kite-api');
+const KiteCodenavButton = require('./elements/kite-codenav-button');
+
+module.exports = class CodenavLineDecoration {
+  constructor(onClick) {
+    this.onClick = onClick;
+    this.activeEditor = null;
+    this.marker = null;
+    this.decoration = null;
+    this.lineInfo = null;
+
+    atom.workspace.observeTextEditors(editor => {
+      editor.onDidChangeCursorPosition(this.onDidChangeCursorPosition.bind(this));
+    });
+    atom.workspace.onDidChangeActiveTextEditor(this.onDidChangeCursorPosition.bind(this));
+    this.onDidChangeCursorPosition();
+  }
+
+  dispose() {
+    this.marker && this.marker.destroy();
+  }
+
+  enabled() {
+    return atom.config.get('kite.enableCodeFinderLineDecoration');
+  }
+
+  async onDidChangeCursorPosition() {
+    if (!this.enabled()) {
+      return;
+    }
+    this.dispose();
+
+    const editor = atom.workspace.getActiveTextEditor();
+    if (!editor) {
+      return;
+    }
+    const curBufPos = editor.getLastCursor().getBufferPosition();
+
+    const applicable = this.lineInfo && this.lineInfo.projectReady !== undefined;
+    const ready = this.lineInfo && this.lineInfo.projectReady;
+    if (editor !== this.activeEditor || (applicable && !ready)) {
+      await this.reset(editor);
+    } else if (editor.hasMultipleCursors()) {
+      await this.reset(editor);
+      return;
+    }
+
+    if (this.lineInfo && this.lineInfo.projectReady) {
+      this.marker = editor.markBufferPosition(curBufPos);
+      this.decoration = editor.decorateMarker(this.marker, {
+        type: 'overlay',
+        item: KiteCodenavButton(
+          this.lineInfo.inlineMessage,
+          this.onClick,
+          {
+            lineHeightPx: editor.getLineHeightInPixels(),
+            lineLengthPx: editor.element.pixelPositionForBufferPosition(
+              [curBufPos.row, Infinity]
+            ).left,
+            cursorColPx: editor.element.pixelPositionForBufferPosition(curBufPos).left,
+            charWidth: editor.getDefaultCharWidth(),
+          }
+        ),
+        position: 'head',
+      });
+    }
+  }
+
+  async reset(editor) {
+    this.dispose();
+    this.activeEditor = editor;
+    this.lineInfo = undefined;
+    const info = await this.fetchDecoration(editor.getPath());
+    if (!info) {
+      return;
+    }
+    this.lineInfo = info;
+  }
+
+  async fetchDecoration(filename) {
+    try {
+      const resp = await KiteAPI.getLineDecoration(filename);
+      if (resp && !resp.err) {
+        return {
+          inlineMessage: resp.inline_message,
+          hoverMessage: resp.hover_message,
+          projectReady: resp.project_ready,
+        };
+      }
+    } catch (e) {
+      console.log(e, e.data);
+    }
+    return null;
+  }
+};

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -48,7 +48,8 @@ module.exports = class CodenavLineDecoration {
     if (this.lineInfo && this.lineInfo.projectReady) {
       this.marker = editor.markBufferPosition(curBufPos);
       this.decoration = editor.decorateMarker(this.marker, {
-        type: 'overlay',
+        type: 'block',
+        position: 'after',
         item: KiteCodenavButton(
           this.lineInfo.inlineMessage,
           this.onClick,
@@ -57,11 +58,9 @@ module.exports = class CodenavLineDecoration {
             lineLengthPx: editor.element.pixelPositionForBufferPosition(
               [curBufPos.row, Infinity]
             ).left,
-            cursorColPx: editor.element.pixelPositionForBufferPosition(curBufPos).left,
             charWidth: editor.getDefaultCharWidth(),
           }
         ),
-        position: 'head',
       });
     }
   }

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -38,7 +38,7 @@ module.exports = class CodenavLineDecoration {
 
     const applicable = this.lineInfo && this.lineInfo.projectReady !== undefined;
     const ready = this.lineInfo && this.lineInfo.projectReady;
-    if (editor !== this.activeEditor || (applicable && !ready)) {
+    if (!this.lineInfo || editor !== this.activeEditor || (applicable && !ready)) {
       await this.reset(editor);
     } else if (editor.hasMultipleCursors()) {
       await this.reset(editor);

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -70,7 +70,7 @@ module.exports = class CodenavLineDecoration {
   async reset(editor) {
     this.dispose();
     this.activeEditor = editor;
-    this.lineInfo = undefined;
+    this.lineInfo = null;
     const info = await this.fetchDecoration(editor.getPath());
     if (!info) {
       return;
@@ -89,7 +89,7 @@ module.exports = class CodenavLineDecoration {
         };
       }
     } catch (e) {
-      console.log(e, e.data);
+      // pass
     }
     return null;
   }

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -9,11 +9,11 @@ module.exports = class CodenavLineDecoration {
     this.decoration = null;
     this.lineInfo = null;
 
+    this.onDidChangeCursorPosition();
     atom.workspace.observeTextEditors(editor => {
       editor.onDidChangeCursorPosition(this.onDidChangeCursorPosition.bind(this));
     });
     atom.workspace.onDidChangeActiveTextEditor(this.onDidChangeCursorPosition.bind(this));
-    this.onDidChangeCursorPosition();
   }
 
   dispose() {
@@ -46,6 +46,8 @@ module.exports = class CodenavLineDecoration {
     }
 
     if (this.lineInfo && this.lineInfo.projectReady) {
+      // Must dispose before marking to avoid multiple decorations
+      this.dispose();
       this.marker = editor.markBufferPosition(curBufPos);
       this.decoration = editor.decorateMarker(this.marker, {
         type: 'block',

--- a/lib/elements/kite-codenav-button.js
+++ b/lib/elements/kite-codenav-button.js
@@ -1,0 +1,36 @@
+function KiteCodenavButton(message, onClick, { lineHeightPx, lineLengthPx, cursorColPx, charWidth }) {
+  // <div class="kite-codenav-decoration">
+  //    <button onclick={onClick}>
+  //      {logo}
+  //      <div class="text">
+  //        {message}
+  //      </div>
+  //    </button>
+  // </div>
+
+  // Atom adds a margin style to the decoration element to place the element
+  // at the bottom of the cursor. These adjustments are relative to this
+  // starting margin, moving the decoration upward and to the right
+  const div = document.createElement('div');
+  div.className = 'kite-codenav-decoration';
+  div.style.marginTop = `-${lineHeightPx}px`;
+  div.style.marginLeft = `${lineLengthPx - cursorColPx + 5 * charWidth}px`;
+
+  const button = document.createElement('button');
+  button.onclick = onClick;
+
+  const logo = document.createElement('kite-logo');
+  logo.className = 'inline';
+
+  const textDiv = document.createElement('div');
+  textDiv.className = 'text';
+  const text = document.createTextNode(`${message}`);
+
+  div.appendChild(button);
+  button.appendChild(logo);
+  button.appendChild(textDiv);
+  textDiv.appendChild(text);
+  return div;
+}
+
+module.exports = KiteCodenavButton;

--- a/lib/elements/kite-codenav-button.js
+++ b/lib/elements/kite-codenav-button.js
@@ -15,7 +15,7 @@ function KiteCodenavButton(message, onClick, {
   // Atom adds a margin style to the decoration element to place the element
   // below the current line for type: block, position: after. These
   // adjustments are relative to this starting margin, moving the
-  // decoration downward and to the right.
+  // decoration upward and to the right.
   const div = document.createElement('div');
   div.className = 'kite-codenav-decoration';
   div.style.marginTop = `-${lineHeightPx}px`;

--- a/lib/elements/kite-codenav-button.js
+++ b/lib/elements/kite-codenav-button.js
@@ -1,4 +1,8 @@
-function KiteCodenavButton(message, onClick, { lineHeightPx, lineLengthPx, cursorColPx, charWidth }) {
+function KiteCodenavButton(message, onClick, {
+  charWidth,
+  lineHeightPx,
+  lineLengthPx,
+}) {
   // <div class="kite-codenav-decoration">
   //    <button onclick={onClick}>
   //      {logo}
@@ -9,12 +13,13 @@ function KiteCodenavButton(message, onClick, { lineHeightPx, lineLengthPx, curso
   // </div>
 
   // Atom adds a margin style to the decoration element to place the element
-  // at the bottom of the cursor. These adjustments are relative to this
-  // starting margin, moving the decoration upward and to the right
+  // below the current line for type: block, position: after. These
+  // adjustments are relative to this starting margin, moving the
+  // decoration downward and to the right.
   const div = document.createElement('div');
   div.className = 'kite-codenav-decoration';
   div.style.marginTop = `-${lineHeightPx}px`;
-  div.style.marginLeft = `${lineLengthPx - cursorColPx + 5 * charWidth}px`;
+  div.style.marginLeft = `${lineLengthPx + 5 * charWidth}px`;
 
   const button = document.createElement('button');
   button.onclick = onClick;

--- a/lib/elements/kite-logo.js
+++ b/lib/elements/kite-logo.js
@@ -15,8 +15,7 @@ class KiteLogo extends HTMLElement {
     return this;
   }
 
-  constructor() {
-    super();
+  connectedCallback() {
     if (this.hasAttribute('sync')) {
       this.innerHTML = syncLogoSvg;
     } else if (this.hasAttribute('small')) {

--- a/lib/kite.js
+++ b/lib/kite.js
@@ -7,6 +7,7 @@ const { DEFAULT_MAX_FILE_SIZE } = require('kite-api');
 
 let child_process,
   CompositeDisposable,
+  CodenavLineDecoration,
   AccountManager,
   Logger,
   completions,
@@ -104,6 +105,7 @@ const Kite = (module.exports = {
       KSGShortcut = require('./ksg/status-shortcut');
       BracketMarker = require('./bracket-marker');
       Codenav = require('./codenav');
+      CodenavLineDecoration = require('./codenav-decoration');
     }
 
     metrics.featureRequested('starting');
@@ -137,12 +139,14 @@ const Kite = (module.exports = {
     this.notifications = new NotificationsCenter(this.app);
     this.reporter = new RollbarReporter();
     this.codenav = new Codenav(this.notifications);
+    this.codenavLineDecoration = new CodenavLineDecoration(() => this.codenav.relatedCodeFromLine());
 
     // All these objects have a dispose method so we can just
     // add them to the subscription.
     this.subscriptions.add(this.app);
     this.subscriptions.add(this.notifications);
     this.subscriptions.add(this.reporter);
+    this.subscriptions.add(this.codenavLineDecoration);
 
     this.getStatusPanel().setApp(this.app);
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "element-resize-detector": "^1.1.11",
     "fuzzaldrin-plus": "^0.4.1",
     "getmac": "1.2.1",
-    "kite-api": "=3.18.0",
+    "kite-api": "=3.19.0",
     "kite-connector": "=3.12.0",
     "kite-installer": "=3.16.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "title": "Show welcome notification on startup",
       "description": "Whether or not to show the Kite welcome notification on startup."
     },
+    "enableCodeFinderLineDecoration": {
+      "type": "boolean",
+      "default": "true",
+      "title": "Enable codefinder decoration",
+      "description": "Show a clickable decoration on the cursor line that starts a line-based search for related code."
+    },
     "enableCompletions": {
       "type": "boolean",
       "default": true,

--- a/styles/kite-decoration.less
+++ b/styles/kite-decoration.less
@@ -1,0 +1,28 @@
+@import "variables";
+
+.kite-codenav-decoration {
+  // Programatically given marginTop and marginLeft
+
+  button {
+    background: none!important;
+    border: none;
+    padding: 0!important;
+    opacity: 0.6;
+    display:flex;
+    justify-content: space-between;
+  }
+
+  kite-logo {
+    margin-top: -0.08rem;
+    width: 1rem;
+    height: 1rem;
+    svg polygon {
+      fill: @blue-color;
+    }
+  }
+
+  .text {
+    color: @blue-color;
+    margin-left: 0.4rem;
+  }
+}

--- a/styles/kite-decoration.less
+++ b/styles/kite-decoration.less
@@ -10,6 +10,7 @@
     opacity: 0.6;
     display:flex;
     justify-content: space-between;
+    flex-wrap: nowrap;
   }
 
   kite-logo {
@@ -24,5 +25,6 @@
   .text {
     color: @blue-color;
     margin-left: 0.4rem;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/11934 for Atom

### What was done
- Added a click-able line decoration for predictive navigation when it's enabled
<img width="715" alt="Screen Shot 2021-01-06 at 4 44 21 PM" src="https://user-images.githubusercontent.com/18232816/103836651-884eeb80-503e-11eb-958a-02e7f9445c3f.png">

@its-dhung Lmk how this looks, changes you'd make, or if you want to take a pass on the styling