### PR TITLE
Hide Line Decoration During Typing

### DIFF
--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -8,10 +8,12 @@ module.exports = class CodenavLineDecoration {
     this.marker = null;
     this.decoration = null;
     this.lineInfo = null;
+    this.editTimeout = null;
 
     this.onDidChangeCursorPosition();
     atom.workspace.observeTextEditors(editor => {
       editor.onDidChangeCursorPosition(this.onDidChangeCursorPosition.bind(this));
+      editor.onDidChange(this.onDidChange.bind(this));
     });
     atom.workspace.onDidChangeActiveTextEditor(this.onDidChangeCursorPosition.bind(this));
   }
@@ -24,12 +26,35 @@ module.exports = class CodenavLineDecoration {
     return atom.config.get('kite.enableCodeFinderLineDecoration');
   }
 
-  async onDidChangeCursorPosition() {
+  // Hide the decoration when the user is changing buffer contents
+  // onDidChangeCursorPosition event.textChanged !== true for deletions
+  // So we hook into onDidChange instead
+  onDidChange() {
+    if (!this.enabled()) {
+      return;
+    }
+    this.dispose();
+    if (this.editTimeout !== null) {
+      clearTimeout(this.editTimeout);
+    }
+    this.editTimeout = setTimeout(() => {
+      this.decorate();
+      this.editTimeout = null;
+    }, 1000);
+  }
+
+  onDidChangeCursorPosition() {
     if (!this.enabled()) {
       return;
     }
     this.dispose();
 
+    if (this.editTimeout === null) {
+      this.decorate();
+    }
+  }
+
+  async decorate() {
     const editor = atom.workspace.getActiveTextEditor();
     if (!editor) {
       return;

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -38,8 +38,9 @@ module.exports = class CodenavLineDecoration {
       clearTimeout(this.editTimeout);
     }
     this.editTimeout = setTimeout(() => {
-      this.decorate();
-      this.editTimeout = null;
+      // onDidChange does not need to 'respectTimeout'
+      // because it handled clearing any previously set timeouts
+      this.decorate(false);
     }, 1000);
   }
 
@@ -54,7 +55,7 @@ module.exports = class CodenavLineDecoration {
     }
   }
 
-  async decorate() {
+  async decorate(respectTimeout = true) {
     const editor = atom.workspace.getActiveTextEditor();
     if (!editor) {
       return;
@@ -67,6 +68,11 @@ module.exports = class CodenavLineDecoration {
       await this.reset(editor);
     } else if (editor.hasMultipleCursors()) {
       await this.reset(editor);
+      return;
+    }
+
+    const timeoutInProgress = this.editTimeout !== null;
+    if (respectTimeout && timeoutInProgress) {
       return;
     }
 
@@ -90,6 +96,8 @@ module.exports = class CodenavLineDecoration {
         ),
       });
     }
+
+    this.editTimeout = null;
   }
 
   async reset(editor) {

--- a/lib/codenav-decoration.js
+++ b/lib/codenav-decoration.js
@@ -40,6 +40,7 @@ module.exports = class CodenavLineDecoration {
     this.editTimeout = setTimeout(() => {
       // onDidChange does not need to 'respectTimeout'
       // because it handled clearing any previously set timeouts
+      // This also tells the function to nullify editTimeout at the end
       this.decorate(false);
     }, 1000);
   }
@@ -56,48 +57,55 @@ module.exports = class CodenavLineDecoration {
   }
 
   async decorate(respectTimeout = true) {
-    const editor = atom.workspace.getActiveTextEditor();
-    if (!editor) {
-      return;
-    }
-    const curBufPos = editor.getLastCursor().getBufferPosition();
+    try {
+      const editor = atom.workspace.getActiveTextEditor();
+      if (!editor) {
+        return;
+      }
+      const curBufPos = editor.getLastCursor().getBufferPosition();
 
-    const applicable = this.lineInfo && this.lineInfo.projectReady !== undefined;
-    const ready = this.lineInfo && this.lineInfo.projectReady;
-    if (!this.lineInfo || editor !== this.activeEditor || (applicable && !ready)) {
-      await this.reset(editor);
-    } else if (editor.hasMultipleCursors()) {
-      await this.reset(editor);
-      return;
-    }
+      const applicable = this.lineInfo && this.lineInfo.projectReady !== undefined;
+      const ready = this.lineInfo && this.lineInfo.projectReady;
+      if (!this.lineInfo || editor !== this.activeEditor || (applicable && !ready)) {
+        await this.reset(editor);
+      } else if (editor.hasMultipleCursors()) {
+        await this.reset(editor);
+        return;
+      }
 
-    const timeoutInProgress = this.editTimeout !== null;
-    if (respectTimeout && timeoutInProgress) {
-      return;
-    }
+      const timeoutInProgress = this.editTimeout !== null;
+      if (respectTimeout && timeoutInProgress) {
+        return;
+      }
 
-    if (this.lineInfo && this.lineInfo.projectReady) {
-      // Must dispose before marking to avoid multiple decorations
-      this.dispose();
-      this.marker = editor.markBufferPosition(curBufPos);
-      this.decoration = editor.decorateMarker(this.marker, {
-        type: 'block',
-        position: 'after',
-        item: KiteCodenavButton(
-          this.lineInfo.inlineMessage,
-          this.onClick,
-          {
-            lineHeightPx: editor.getLineHeightInPixels(),
-            lineLengthPx: editor.element.pixelPositionForBufferPosition(
-              [curBufPos.row, Infinity]
-            ).left,
-            charWidth: editor.getDefaultCharWidth(),
-          }
-        ),
-      });
+      if (this.lineInfo && this.lineInfo.projectReady) {
+        // Must dispose before marking to avoid multiple decorations
+        this.dispose();
+        this.marker = editor.markBufferPosition(curBufPos);
+        this.decoration = editor.decorateMarker(this.marker, {
+          type: 'block',
+          position: 'after',
+          item: KiteCodenavButton(
+            this.lineInfo.inlineMessage,
+            this.onClick,
+            {
+              lineHeightPx: editor.getLineHeightInPixels(),
+              lineLengthPx: editor.element.pixelPositionForBufferPosition(
+                [curBufPos.row, Infinity]
+              ).left,
+              charWidth: editor.getDefaultCharWidth(),
+            }
+          ),
+        });
+      }
+    } finally {
+      // Needs cleanup to ensure early exits for timeout calls
+      // will allow for onDidChangeCursorPosition to decorate
+      // Handling this within this async function ensures immediacy
+      if (!respectTimeout) {
+        this.editTimeout = null;
+      }
     }
-
-    this.editTimeout = null;
   }
 
   async reset(editor) {


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/12335 for Atom

The decoration here behaves differently from VSCode's in that it does not disappear when navigating with the keyboard. This is because Atom's API does not expose a 'source' of the cursor change like VSCode does.