### PR TITLE
Status Panel Button And Styling

### DIFF
--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -260,10 +260,8 @@ class KiteStatusPanel extends HTMLElement {
     switch (status.state) {
       case STATES.UNSUPPORTED:
         content = `
-          <div class="center-aligned-line">
-            <div class="text-danger">
-              Kite engine is not available on your system
-            </div>
+          <div class="center-aligned-line text-danger">
+            Kite engine is not available on your system
             ${dot('text-danger')}
           </div>
         `;
@@ -367,8 +365,8 @@ class KiteStatusPanel extends HTMLElement {
             break;
           case editor && editor.getText().length >= maxFileSize:
             content = `
-              <div class="center-aligned-line">
-                <div class="text-warning">The current file is too large for Kite to handle</div>
+              <div class="center-aligned-line text-warning">
+                The current file is too large for Kite to handle
                 ${dot('text-warning')}
               </div>
             `;

--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -10,7 +10,6 @@ const LinkScheme = require('../link-scheme');
 const DataLoader = require('../data-loader');
 
 const { STATES } = KiteAPI;
-const dot = '<span class="dot">•</span>';
 
 class KiteStatusPanel extends HTMLElement {
   constructor(kite) {
@@ -256,64 +255,154 @@ class KiteStatusPanel extends HTMLElement {
   }
 
   renderStatus(status, syncStatus, isUserAuthenticated, maxFileSize) {
+    const dot = (cls = '') => `<div class="dot ${cls}">•</div>`;
     let content = '';
     switch (status.state) {
       case STATES.UNSUPPORTED:
-        content = `<div class="text-danger">Kite engine is not available on your system ${dot}</div>`;
+        content = `
+          <div class="center-aligned-line">
+            <div class="text-danger">
+              Kite engine is not available on your system
+            </div>
+            ${dot('text-danger')}
+          </div>
+        `;
         break;
-
       case STATES.UNINSTALLED:
         if (this.Kite.installing) {
-          content = `<div class="text-danger">Installing components ${dot}<br/>
-          Kite will launch automatically when ready.</div>`;
+          content = `
+            <div class="center-aligned-line text-danger">
+              <div class="text-container">
+                <div class="text-line">Installing components</div>
+                <div class="text-line">Kite will launch automatically when ready</div>
+              </div>
+              ${dot('text-danger')}
+            </div>
+          `;
         } else {
-          content = `<div class="text-danger">Kite engine is not installed ${dot}</div>`;
-          content += '<a href="kite-atom-internal://install" class="btn btn-error">Install now</a>';
+          content = `
+            <div class="center-aligned-line text-danger">
+              Kite engine is not installed
+              ${dot('text-danger')}
+            </div>
+            <a href="kite-atom-internal://install" class="btn btn-error">
+              Install now
+            </a>
+          `;
         }
         break;
       case STATES.INSTALLED: {
         if (KiteAPI.hasManyKiteInstallation() || KiteAPI.hasManyKiteEnterpriseInstallation()) {
-          content = `<div class="text-danger">Kite engine is not running ${dot}<br/>
-          You have multiple versions of Kite installed. Please launch your desired one.</div>`;
+          content = `
+            <div class="center-aligned-line text-danger">
+              <div class="text-container">
+                <div class="text-line">Kite engine is not running</div>
+                <div class="text-line">You have multiple versions of Kite installed.</div>
+                <div class="text-line">Please launch your desired one.</div>
+              </div>
+              ${dot('')}
+            </div>
+          `;
         } else if (status.kiteInstalled && status.kiteEnterpriseInstalled) {
           content = `
-          <div class="text-danger">Kite engine is not running ${dot}<br/>
-          Which version of kite do you want to launch?</div>
-          <a href="kite-atom-internal://start-enterprise"
-             class="btn btn-purple">Launch Kite Enterprise</a><br/>
-          <a href="kite-atom-internal://start" class="btn btn-info">Launch Kite cloud</a>`;
+            <div class="center-aligned-line text-danger">
+              <div class="text-container">
+                <div class="text-line">Kite engine is not running</div>
+                <div class="text-line">Which version of kite do you want to launch?</div>
+              </div>
+              ${dot('text-danger')}
+            </div>
+            <a href="kite-atom-internal://start-enterprise" class="btn btn-purple">
+              Launch Kite Enterprise
+            </a>
+            <br/>
+            <a href="kite-atom-internal://start" class="btn btn-info">
+              Launch Kite cloud
+            </a>
+          `;
         } else if (status.kiteInstalled) {
-          content = `<div class="text-danger">Kite engine is not running ${dot}</div>
-          <a href="kite-atom-internal://start" class="btn btn-error">Launch now</a>`;
+          content = `
+            <div class="center-aligned-line text-danger">
+              Kite engine is not running
+              ${dot('text-danger')}
+            </div>
+            <a href="kite-atom-internal://start" class="btn btn-error">
+              Launch now
+            </a>
+          `;
         } else {
-          content = `<div class="text-danger">Kite engine is not running ${dot}</div>
-          <a href="kite-atom-internal://start-enterprise" class="btn btn-error">Launch now</a>`;
+          content = `
+            <div class="center-aligned-line text-danger">
+              Kite engine is not running
+              ${dot('text-danger')}
+            </div>
+            <a href="kite-atom-internal://start-enterprise" class="btn btn-error">
+              Launch now
+            </a>
+          `;
         }
         break;
       }
       case STATES.RUNNING:
         content = `
-          <div class="text-danger">Kite engine is not reachable</div>
+          <div class="center-aligned-line text-danger">
+            Kite engine is not reachable
+            ${dot('text-danger')}
+          </div>
         `;
         break;
       case STATES.READY:
+        let buttonLink = '';
         const editor = atom.workspace.getActiveTextEditor();
-        if (!editor) {
-          content = `<div>Open a supported file to see Kite's status ${dot}</div>`;
-        } else if (!this.Kite.getModule('editors').isGrammarSupported(editor)) {
-          content = `<div>Open a supported file to see Kite's status ${dot}</div>`;
-        } else {
-          if (editor && editor.getText().length >= maxFileSize) {
+        switch (true) {
+          case !editor:
+            // fallthrough
+          case !this.Kite.getModule('editors').isGrammarSupported(editor):
             content = `
-            <div class="text-warning">The current file is too large for Kite to handle ${dot}</div>`;
-          } else {
-            if (syncStatus && syncStatus.long !== undefined) {
-              content = `<div class="ready">${syncStatus.long} ${dot}</div>`;
+              <div class="center-aligned-line">
+                <div>Open a supported file to see Kite's status</div>
+                ${dot()}
+              </div>
+            `;
+            break;
+          case editor && editor.getText().length >= maxFileSize:
+            content = `
+              <div class="center-aligned-line">
+                <div class="text-warning">The current file is too large for Kite to handle</div>
+                ${dot('text-warning')}
+              </div>
+            `;
+            break;
+          case syncStatus && syncStatus.long !== undefined:
+            if (syncStatus.button && syncStatus.button.action == 'open') {
+              buttonLink = `
+                <a href="${syncStatus.button.link}" class="btn btn-left">
+                  ${syncStatus.button.text}
+                </a>
+              `;
             }
-          }
+            // The long status is split at periods. Each line will get their own row
+            // So it's best not to have more than two sentences in the long status
+            const textLines = syncStatus.long
+              .split('.')
+              .filter(content => content !== '')
+              .map(content => `<div class="text-line">${content}</div>`)
+              .join('');
+            const color = syncStatus.long.includes('ready') ? 'ready' : 'text-warning';
+            content = `
+              <div class="center-aligned-line">
+                ${buttonLink}
+                <div class="${color} text-container">
+                  ${textLines}
+                </div>
+                ${dot(color)}
+              </div>
+            `;
+            break;
         }
 
-        if (!isUserAuthenticated) {
+        // If there's another button, don't render the log in button to keep the UI simple
+        if (!isUserAuthenticated && buttonLink === '') {
           content = `
           <div>
             Kite engine is not logged in

--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -256,6 +256,7 @@ class KiteStatusPanel extends HTMLElement {
 
   renderStatus(status, syncStatus, isUserAuthenticated, maxFileSize) {
     const dot = (cls = '') => `<div class="dot ${cls}">•</div>`;
+    status.state = STATES.READY;
     let content = '';
     switch (status.state) {
       case STATES.UNSUPPORTED:
@@ -386,7 +387,7 @@ class KiteStatusPanel extends HTMLElement {
               .filter(content => content !== '')
               .map(content => `<div class="text-line">${content}</div>`)
               .join('');
-            const color = syncStatus.long.includes('ready') ? 'ready' : 'text-warning';
+            const color = keywordToColorClass(syncStatus.long);
             content = `
               <div class="center-aligned-line">
                 ${buttonLink}
@@ -421,6 +422,18 @@ class KiteStatusPanel extends HTMLElement {
       <div class="right">${status.state >= STATES.READY ? '<a href="kite-atom-internal://open-account-web">Account</a>' : ''
 }</div>
     </div>`;
+  }
+}
+
+function keywordToColorClass(text) {
+  text = text.toLowerCase();
+  switch (true) {
+    case text.includes('ready'):
+      return 'ready';
+    case text.includes('locked'):
+      return 'text-danger';
+    default:
+      return 'text-warning';
   }
 }
 

--- a/lib/elements/kite-status-panel.js
+++ b/lib/elements/kite-status-panel.js
@@ -158,20 +158,6 @@ class KiteStatusPanel extends HTMLElement {
           })
           .then(() => this.renderCurrent());
         break;
-      case 'start-enterprise':
-        this.pendingStatus('Launching Kite');
-        this.starting = true;
-        promise = this.app
-          .startEnterprise()
-          .then(() => delayPromise(() => Promise.resolve(), 3000))
-          .then(() => {
-            this.starting = false;
-          })
-          .catch(() => {
-            this.starting = false;
-          })
-          .then(() => this.renderCurrent());
-        break;
       case 'login':
         this.app.login();
         this.hide();
@@ -207,18 +193,7 @@ class KiteStatusPanel extends HTMLElement {
     }
     const editor = atom.workspace.getActiveTextEditor();
     const promises = [
-      KiteAPI.checkHealth().then(state => {
-        return Promise.all([
-          KiteAPI.isKiteInstalled().then(() => true, () => false),
-          KiteAPI.isKiteEnterpriseInstalled().then(() => true, () => false),
-        ]).then(([kiteInstalled, kiteEnterpriseInstalled]) => {
-          return {
-            state,
-            kiteInstalled,
-            kiteEnterpriseInstalled,
-          };
-        });
-      }),
+      KiteAPI.checkHealth(),
       DataLoader.getUserAccountInfo().catch(() => { }),
       DataLoader.getStatus(editor),
       DataLoader.isUserAuthenticated().catch(() => { }),
@@ -230,11 +205,11 @@ class KiteStatusPanel extends HTMLElement {
     });
   }
 
-  render(status, account, syncStatus, isUserAuthenticated, maxFileSize) {
+  render(state, account, syncStatus, isUserAuthenticated, maxFileSize) {
     this.innerHTML = `
       ${this.renderSubscription(status)}
       ${this.renderLinks(account)}
-      ${this.renderStatus(status, syncStatus, isUserAuthenticated, maxFileSize)}
+      ${this.renderStatus(state, syncStatus, isUserAuthenticated, maxFileSize)}
     `;
   }
 
@@ -254,11 +229,10 @@ class KiteStatusPanel extends HTMLElement {
     `;
   }
 
-  renderStatus(status, syncStatus, isUserAuthenticated, maxFileSize) {
+  renderStatus(state, syncStatus, isUserAuthenticated, maxFileSize) {
     const dot = (cls = '') => `<div class="dot ${cls}">•</div>`;
-    status.state = STATES.READY;
     let content = '';
-    switch (status.state) {
+    switch (state) {
       case STATES.UNSUPPORTED:
         content = `
           <div class="center-aligned-line text-danger">
@@ -290,37 +264,8 @@ class KiteStatusPanel extends HTMLElement {
           `;
         }
         break;
-      case STATES.INSTALLED: {
-        if (KiteAPI.hasManyKiteInstallation() || KiteAPI.hasManyKiteEnterpriseInstallation()) {
-          content = `
-            <div class="center-aligned-line text-danger">
-              <div class="text-container">
-                <div class="text-line">Kite engine is not running</div>
-                <div class="text-line">You have multiple versions of Kite installed.</div>
-                <div class="text-line">Please launch your desired one.</div>
-              </div>
-              ${dot('')}
-            </div>
-          `;
-        } else if (status.kiteInstalled && status.kiteEnterpriseInstalled) {
-          content = `
-            <div class="center-aligned-line text-danger">
-              <div class="text-container">
-                <div class="text-line">Kite engine is not running</div>
-                <div class="text-line">Which version of kite do you want to launch?</div>
-              </div>
-              ${dot('text-danger')}
-            </div>
-            <a href="kite-atom-internal://start-enterprise" class="btn btn-purple">
-              Launch Kite Enterprise
-            </a>
-            <br/>
-            <a href="kite-atom-internal://start" class="btn btn-info">
-              Launch Kite cloud
-            </a>
-          `;
-        } else if (status.kiteInstalled) {
-          content = `
+      case STATES.INSTALLED:
+        content = `
             <div class="center-aligned-line text-danger">
               Kite engine is not running
               ${dot('text-danger')}
@@ -329,19 +274,7 @@ class KiteStatusPanel extends HTMLElement {
               Launch now
             </a>
           `;
-        } else {
-          content = `
-            <div class="center-aligned-line text-danger">
-              Kite engine is not running
-              ${dot('text-danger')}
-            </div>
-            <a href="kite-atom-internal://start-enterprise" class="btn btn-error">
-              Launch now
-            </a>
-          `;
-        }
         break;
-      }
       case STATES.RUNNING:
         content = `
           <div class="center-aligned-line text-danger">

--- a/spec/elements/kite-status-panel-spec.js
+++ b/spec/elements/kite-status-panel-spec.js
@@ -145,82 +145,6 @@ describe('KiteStatusPanel', () => {
     });
   });
 
-  withKite({runningEnterprise: false}, () => {
-    beforeEach(() => {
-      waitsForPromise(() => status.show().catch(err => console.log(err)));
-    });
-
-    it('displays an action to start kited', () => {
-      const state = status.querySelector('.status');
-
-      expect(state.querySelector('.text-danger').textContent)
-      .toEqual('Kite engine is not running •');
-
-      const button = state.querySelector('a');
-
-      expect(button.href).toEqual('kite-atom-internal://start-enterprise');
-      expect(button.textContent).toEqual('Launch now');
-    });
-
-    describe('clicking on the button', () => {
-      it('starts kited', () => {
-        const button = status.querySelector('a.btn');
-
-        spyOn(app, 'startEnterprise').andReturn(Promise.resolve());
-        click(button);
-
-        expect(app.startEnterprise).toHaveBeenCalled();
-      });
-    });
-  });
-
-  withKite({
-    running: false,
-    runningEnterprise: false,
-  }, () => {
-    beforeEach(() => {
-      waitsForPromise(() => status.show());
-    });
-
-    it('displays an action to start kited', () => {
-      const state = status.querySelector('.status');
-
-      expect(state.querySelector('.text-danger').textContent.replace(/\s+/g, ' '))
-      .toEqual('Kite engine is not running • Which version of kite do you want to launch?');
-
-      const buttons = state.querySelectorAll('a');
-
-      expect(buttons.length).toEqual(2);
-
-      expect(buttons[0].href).toEqual('kite-atom-internal://start-enterprise');
-      expect(buttons[0].textContent).toEqual('Launch Kite Enterprise');
-      expect(buttons[1].href).toEqual('kite-atom-internal://start');
-      expect(buttons[1].textContent).toEqual('Launch Kite cloud');
-    });
-
-    describe('clicking on the enterprise button', () => {
-      it('starts kited', () => {
-        const button = status.querySelector('a.btn');
-
-        spyOn(app, 'startEnterprise').andReturn(Promise.resolve());
-        click(button);
-
-        expect(app.startEnterprise).toHaveBeenCalled();
-      });
-    });
-
-    describe('clicking on the cloud button', () => {
-      it('starts kited', () => {
-        const button = status.querySelectorAll('a.btn')[1];
-
-        spyOn(app, 'start').andReturn(Promise.resolve());
-        click(button);
-
-        expect(app.start).toHaveBeenCalled();
-      });
-    });
-  });
-
   withKite({
     running: false,
     runningEnterprise: false,
@@ -235,7 +159,7 @@ describe('KiteStatusPanel', () => {
       const state = status.querySelector('.status');
 
       expect(state.querySelector('.text-danger').textContent.replace(/\s+/g, ' '))
-      .toEqual(`Kite engine is not running •
+        .toEqual(`Kite engine is not running •
         You have multiple versions of Kite installed.
         Please launch your desired one.`.replace(/\s+/g, ' '));
 

--- a/styles/kite-status-panel.less
+++ b/styles/kite-status-panel.less
@@ -134,6 +134,7 @@ kite-status-panel {
     .center-aligned-line {
       display: flex;
       align-items: center;
+      justify-content: flex-end;
     }
 
     .text-container {

--- a/styles/kite-status-panel.less
+++ b/styles/kite-status-panel.less
@@ -122,17 +122,37 @@ kite-status-panel {
       margin-top: @component-padding;
     }
 
+    .btn-left {
+      margin-right: 1em;
+    }
+
     &:nth-child(1n+2) {
       padding: @component-padding @half-padding 0;
       border-top: 1px solid @subtle-border-color;
     }
 
+    .center-aligned-line {
+      display: flex;
+      align-items: center;
+    }
+
+    .text-container {
+      display: flex;
+      flex-flow: column;
+      word-wrap: break-word;
+      overflow-wrap: break-word;
+      white-space: normal;
+    }
+
+    .text-line {
+      display: inline-block;
+    }
+
     .dot {
       font-size: 2.4em;
       line-height: 0.5em;
-      vertical-align: sub;
-      display: inline-block;
-      margin-left: 0.5em;
+      margin-bottom: 0.12em;
+      margin-left: 0.2em;
     }
 
     .ready .dot {


### PR DESCRIPTION
Addresses https://github.com/kiteco/kiteco/issues/12288 's status panel for Atom

## What was done
- Main use case is for the `all_features_pro` button and text but since I needed specific alignment,
- Refactored various statuses to make things more uniform

## Previews
### Commentary
The login button is suppressed when the status sends over a button. Periods indicate splitting (`Locked until tomorrow. Upgrade now to unlock.`). The spec had the button on the left, though most of Atom's buttons are on the right. I think this looks nice though.
<img width="313" alt="Screen Shot 2021-02-04 at 3 11 41 PM" src="https://user-images.githubusercontent.com/18232816/106969045-f4387880-66fe-11eb-9e91-ed2e729a36af.png">

If a button isn't sent but a message with periods is sent, we'd get something like this, though currently we only send a message with a period with this particular status and we always send a button with it as well. Separately, IMO the login button looks misplaced here and other mockups, but not too sure how to fix.
<img width="272" alt="Screen Shot 2021-02-04 at 3 33 04 PM" src="https://user-images.githubusercontent.com/18232816/106969049-f6023c00-66fe-11eb-9a6b-9db88beb8e87.png">

I saw that the spec had this as red, so I kept it as red, but it seems to me it would look better yellow, since it's a 'pending' kind of message.
<img width="293" alt="Screen Shot 2021-02-04 at 2 48 49 PM" src="https://user-images.githubusercontent.com/18232816/106969108-116d4700-66ff-11eb-9f46-5cc921028fee.png">

### More
<img width="285" alt="Screen Shot 2021-02-04 at 3 08 24 PM" src="https://user-images.githubusercontent.com/18232816/106969068-fe5a7700-66fe-11eb-8447-dfe378e5a3b4.png">
<img width="326" alt="Screen Shot 2021-02-04 at 3 08 14 PM" src="https://user-images.githubusercontent.com/18232816/106969073-01edfe00-66ff-11eb-87a3-bd8efd5a1915.png">
<img width="219" alt="Screen Shot 2021-02-04 at 3 05 18 PM" src="https://user-images.githubusercontent.com/18232816/106969080-04505800-66ff-11eb-81ca-ade627336bf3.png">
<img width="224" alt="Screen Shot 2021-02-04 at 2 58 06 PM" src="https://user-images.githubusercontent.com/18232816/106969094-074b4880-66ff-11eb-8805-2f74e7a82014.png">

### Deprecated(?)
I don't really have the context around these, but our terminology seems different now. Should we remove these? There's a lot of related code lying around, and I didn't want to remove everything at once.
<img width="324" alt="Screen Shot 2021-02-04 at 2 56 19 PM" src="https://user-images.githubusercontent.com/18232816/106969099-0adecf80-66ff-11eb-91af-33a4d3dc4947.png">
<img width="301" alt="Screen Shot 2021-02-04 at 2 53 56 PM" src="https://user-images.githubusercontent.com/18232816/106969105-0e725680-66ff-11eb-9900-b90f30997dcd.png">